### PR TITLE
fix(ux): bugfixes from v0.2.0-rc user testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.2.0-rc",
+  "version": "0.2.1-rc",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain, BrowserWindow, dialog } from 'electron';
 import { SessionManager } from './session-manager';
 import { IdleDetector } from './idle-detector';
 import { SessionStore } from './session-store';
@@ -144,6 +144,21 @@ export function registerIpcHandlers(sessionManager: SessionManager): void {
     const defaults = preferencesStore.reset();
     broadcast('preferences:changed', defaults);
     return defaults;
+  });
+
+  // dialog:open-file — open a native file picker
+  ipcMain.handle('dialog:open-file', async (_event, args?: { filters?: Electron.FileFilter[] }) => {
+    const win = BrowserWindow.getFocusedWindow();
+    if (!win) return null;
+    const result = await dialog.showOpenDialog(win, {
+      properties: ['openFile'],
+      filters: args?.filters || [
+        { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return result.filePaths[0];
   });
 
   // Wire up session manager events to renderer + idle detector

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -37,6 +37,14 @@ app.whenReady().then(() => {
   registerIpcHandlers(sessionManager);
   mainWindow = createWindow();
 
+  // Intercept Ctrl+Tab / Ctrl+Shift+Tab before Chromium eats them
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.control && input.key === 'Tab') {
+      event.preventDefault();
+      mainWindow?.webContents.send('shortcut:cycle-tab', { shift: input.shift });
+    }
+  });
+
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       mainWindow = createWindow();

--- a/src/main/preferences-store.ts
+++ b/src/main/preferences-store.ts
@@ -20,8 +20,6 @@ export function getDefaultPreferences(): SwitchboardPreferences {
     terminalBackgroundImage: null,
     terminalBackgroundOpacity: 0.3,
     sidebarBackgroundImage: null,
-    windowOpacity: 1.0,
-    terminalBackgroundAlpha: 1.0,
     shortcuts: {},
     sessionOrder: [],
     cursorBlink: true,

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -2,6 +2,18 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 const api = {
   platform: process.platform,
+  dialog: {
+    openFile(filters?: Array<{ name: string; extensions: string[] }>) {
+      return ipcRenderer.invoke('dialog:open-file', filters ? { filters } : undefined);
+    },
+  },
+  onCycleTab(callback: (shift: boolean) => void): () => void {
+    const handler = (_event: Electron.IpcRendererEvent, args: { shift: boolean }) => {
+      callback(args.shift);
+    };
+    ipcRenderer.on('shortcut:cycle-tab', handler);
+    return () => ipcRenderer.removeListener('shortcut:cycle-tab', handler);
+  },
   pty: {
     spawn(config: { name: string; cwd: string; command?: string }) {
       return ipcRenderer.invoke('pty:spawn', config);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { SessionsProvider, useSessions } from './state/sessions';
 import { PreferencesProvider, usePreferences } from './state/preferences';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -27,9 +27,23 @@ function AppContent(): React.ReactElement {
     return unsubExit;
   }, [removeSession]);
 
+  // Track active session ID in a ref so the onData callback always sees current value
+  const activeSessionIdRef = useRef(state.activeSessionId);
+  activeSessionIdRef.current = state.activeSessionId;
+
+  // Grace period after tab switch — ignore output from the tab we just left
+  const switchTimestampRef = useRef(0);
+  useEffect(() => {
+    switchTimestampRef.current = Date.now();
+  }, [state.activeSessionId]);
+
   // Mark background tabs as unread when they receive output
   useEffect(() => {
     const unsubData = window.switchboard.pty.onData((sessionId: string) => {
+      // Skip if this is the active session
+      if (sessionId === activeSessionIdRef.current) return;
+      // Skip output within 200ms of a tab switch (prompt redraw noise)
+      if (Date.now() - switchTimestampRef.current < 200) return;
       markUnread(sessionId);
     });
     return unsubData;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -109,6 +109,14 @@ function AppContent(): React.ReactElement {
 
   useKeyboardShortcuts(prefs.shortcuts, shortcutHandlers);
 
+  // Listen for Ctrl+Tab / Ctrl+Shift+Tab forwarded from main process
+  useEffect(() => {
+    const unsub = window.switchboard.onCycleTab((shift) => {
+      cycleSession(shift ? -1 : 1);
+    });
+    return unsub;
+  }, [cycleSession]);
+
   const { uiColors } = prefs;
 
   return (

--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -25,7 +25,7 @@ export default function Header({ activeSessionName, onNewSession, onOpenPreferen
         padding: '0 16px',
       }}
     >
-      <span style={{ fontSize: 14, fontWeight: 600, color: uiColors.headerText }}>
+      <span style={{ fontSize: 'inherit', fontWeight: 600, color: uiColors.headerText }}>
         {activeSessionName || 'Switchboard'}
       </span>
       <div style={{ display: 'flex', gap: 8 }}>
@@ -40,7 +40,7 @@ export default function Header({ activeSessionName, onNewSession, onOpenPreferen
               border: 'none',
               borderRadius: 4,
               padding: '6px 10px',
-              fontSize: 14,
+              fontSize: 'inherit',
               cursor: 'pointer',
             }}
           >
@@ -57,7 +57,7 @@ export default function Header({ activeSessionName, onNewSession, onOpenPreferen
             border: 'none',
             borderRadius: 4,
             padding: '6px 12px',
-            fontSize: 12,
+            fontSize: 'inherit',
             cursor: 'pointer',
           }}
         >

--- a/src/renderer/components/PreferencesModal.tsx
+++ b/src/renderer/components/PreferencesModal.tsx
@@ -8,7 +8,7 @@ interface PreferencesModalProps {
   onClose: () => void;
 }
 
-type Section = 'theme' | 'font' | 'backgrounds' | 'transparency' | 'shortcuts' | 'terminal';
+type Section = 'theme' | 'font' | 'backgrounds' | 'shortcuts' | 'terminal';
 
 export default function PreferencesModal({ isOpen, onClose }: PreferencesModalProps): React.ReactElement | null {
   const { prefs, updatePrefs, resetPrefs } = usePreferences();
@@ -21,7 +21,6 @@ export default function PreferencesModal({ isOpen, onClose }: PreferencesModalPr
     { key: 'theme', label: 'Theme' },
     { key: 'font', label: 'Font' },
     { key: 'backgrounds', label: 'Backgrounds' },
-    { key: 'transparency', label: 'Transparency' },
     { key: 'shortcuts', label: 'Shortcuts' },
     { key: 'terminal', label: 'Terminal' },
   ];
@@ -226,14 +225,34 @@ export default function PreferencesModal({ isOpen, onClose }: PreferencesModalPr
             {activeSection === 'backgrounds' && (
               <div>
                 <div style={{ marginBottom: 14 }}>
-                  <label style={labelStyle}>Terminal Background Image (file path)</label>
-                  <input
-                    type="text"
-                    value={prefs.terminalBackgroundImage || ''}
-                    onChange={(e) => updatePrefs({ terminalBackgroundImage: e.target.value || null })}
-                    placeholder="/path/to/image.png"
-                    style={inputStyle}
-                  />
+                  <label style={labelStyle}>Terminal Background Image</label>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <input
+                      type="text"
+                      value={prefs.terminalBackgroundImage || ''}
+                      onChange={(e) => updatePrefs({ terminalBackgroundImage: e.target.value || null })}
+                      placeholder="/path/to/image.png"
+                      style={{ ...inputStyle, flex: 1 }}
+                    />
+                    <button
+                      onClick={async () => {
+                        const path = await window.switchboard.dialog.openFile();
+                        if (path) updatePrefs({ terminalBackgroundImage: path });
+                      }}
+                      style={{
+                        padding: '6px 12px',
+                        backgroundColor: uiColors.buttonBg,
+                        color: uiColors.buttonText,
+                        border: `1px solid ${uiColors.buttonBorder}`,
+                        borderRadius: 4,
+                        fontSize: 12,
+                        cursor: 'pointer',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      Browse...
+                    </button>
+                  </div>
                 </div>
                 <div style={{ marginBottom: 14 }}>
                   <label style={labelStyle}>Terminal Background Opacity ({prefs.terminalBackgroundOpacity.toFixed(1)})</label>
@@ -248,43 +267,34 @@ export default function PreferencesModal({ isOpen, onClose }: PreferencesModalPr
                   />
                 </div>
                 <div style={{ marginBottom: 14 }}>
-                  <label style={labelStyle}>Sidebar Background Image (file path)</label>
-                  <input
-                    type="text"
-                    value={prefs.sidebarBackgroundImage || ''}
-                    onChange={(e) => updatePrefs({ sidebarBackgroundImage: e.target.value || null })}
-                    placeholder="/path/to/image.png"
-                    style={inputStyle}
-                  />
-                </div>
-              </div>
-            )}
-
-            {activeSection === 'transparency' && (
-              <div>
-                <div style={{ marginBottom: 14 }}>
-                  <label style={labelStyle}>Window Opacity ({prefs.windowOpacity.toFixed(1)})</label>
-                  <input
-                    type="range"
-                    min={0.5}
-                    max={1}
-                    step={0.05}
-                    value={prefs.windowOpacity}
-                    onChange={(e) => updatePrefs({ windowOpacity: parseFloat(e.target.value) })}
-                    style={{ width: '100%' }}
-                  />
-                </div>
-                <div style={{ marginBottom: 14 }}>
-                  <label style={labelStyle}>Terminal Background Alpha ({prefs.terminalBackgroundAlpha.toFixed(1)})</label>
-                  <input
-                    type="range"
-                    min={0}
-                    max={1}
-                    step={0.05}
-                    value={prefs.terminalBackgroundAlpha}
-                    onChange={(e) => updatePrefs({ terminalBackgroundAlpha: parseFloat(e.target.value) })}
-                    style={{ width: '100%' }}
-                  />
+                  <label style={labelStyle}>Sidebar Background Image</label>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <input
+                      type="text"
+                      value={prefs.sidebarBackgroundImage || ''}
+                      onChange={(e) => updatePrefs({ sidebarBackgroundImage: e.target.value || null })}
+                      placeholder="/path/to/image.png"
+                      style={{ ...inputStyle, flex: 1 }}
+                    />
+                    <button
+                      onClick={async () => {
+                        const path = await window.switchboard.dialog.openFile();
+                        if (path) updatePrefs({ sidebarBackgroundImage: path });
+                      }}
+                      style={{
+                        padding: '6px 12px',
+                        backgroundColor: uiColors.buttonBg,
+                        color: uiColors.buttonText,
+                        border: `1px solid ${uiColors.buttonBorder}`,
+                        borderRadius: 4,
+                        fontSize: 12,
+                        cursor: 'pointer',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      Browse...
+                    </button>
+                  </div>
                 </div>
               </div>
             )}

--- a/src/renderer/components/SessionTab.tsx
+++ b/src/renderer/components/SessionTab.tsx
@@ -39,7 +39,7 @@ export default function SessionTab({ session, isActive, hasUnread, onSelect, onC
         backgroundColor: isActive ? uiColors.tabActiveBg : 'transparent',
         color: isActive ? uiColors.tabActiveText : uiColors.tabInactiveText,
         cursor: 'pointer',
-        fontSize: 13,
+        fontSize: 'inherit',
         textAlign: 'left',
         transition: 'background-color 0.15s',
       }}

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { DndContext, closestCenter, DragEndEvent, Modifier } from '@dnd-kit/core';
+import { DndContext, closestCenter, DragEndEvent, Modifier, useSensor, useSensors, PointerSensor } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import { useSessions } from '../state/sessions';
 import { usePreferences } from '../state/preferences';
@@ -23,6 +23,9 @@ export default function Sidebar(): React.ReactElement {
   const { uiColors } = prefs;
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
 
   const handleContextMenu = useCallback((sessionId: string, e: React.MouseEvent) => {
     if (isDragging) return;
@@ -95,6 +98,7 @@ export default function Sidebar(): React.ReactElement {
           </div>
         ) : (
           <DndContext
+            sensors={sensors}
             collisionDetection={closestCenter}
             modifiers={[restrictToVerticalAxis]}
             onDragStart={() => setIsDragging(true)}

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -79,7 +79,7 @@ export default function Sidebar(): React.ReactElement {
       <div
         style={{
           padding: '16px 14px 12px',
-          fontSize: 12,
+          fontSize: 'inherit',
           fontWeight: 600,
           textTransform: 'uppercase',
           letterSpacing: '0.05em',
@@ -90,7 +90,7 @@ export default function Sidebar(): React.ReactElement {
       </div>
       <div style={{ flex: 1, padding: '0 6px', overflowY: 'auto' }}>
         {state.sessions.length === 0 ? (
-          <div style={{ padding: '0 8px', fontSize: 13, color: uiColors.appTextFaint }}>
+          <div style={{ padding: '0 8px', fontSize: 'inherit', color: uiColors.appTextFaint }}>
             No sessions yet
           </div>
         ) : (

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -77,8 +77,26 @@ export default function Sidebar(): React.ReactElement {
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
+        position: 'relative',
       }}
     >
+      {prefs.sidebarBackgroundImage && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundImage: `url(${prefs.sidebarBackgroundImage})`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            opacity: 0.15,
+            pointerEvents: 'none',
+            zIndex: 0,
+          }}
+        />
+      )}
       <div
         style={{
           padding: '16px 14px 12px',
@@ -87,11 +105,13 @@ export default function Sidebar(): React.ReactElement {
           textTransform: 'uppercase',
           letterSpacing: '0.05em',
           color: uiColors.sidebarHeaderText,
+          position: 'relative',
+          zIndex: 1,
         }}
       >
         Sessions
       </div>
-      <div style={{ flex: 1, padding: '0 6px', overflowY: 'auto' }}>
+      <div style={{ flex: 1, padding: '0 6px', overflowY: 'auto', position: 'relative', zIndex: 1 }}>
         {state.sessions.length === 0 ? (
           <div style={{ padding: '0 8px', fontSize: 'inherit', color: uiColors.appTextFaint }}>
             No sessions yet

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -23,7 +23,7 @@ export default function StatusBar(): React.ReactElement {
         alignItems: 'center',
         justifyContent: 'space-between',
         padding: '0 12px',
-        fontSize: 11,
+        fontSize: '0.85em',
         color: uiColors.appTextFaint,
       }}
     >

--- a/src/renderer/components/TerminalPane.tsx
+++ b/src/renderer/components/TerminalPane.tsx
@@ -140,7 +140,7 @@ export default function TerminalPane({ sessionId, visible, searchVisible, onSear
       unsubData();
       terminal.dispose();
     };
-  }, [sessionId]);
+  }, [sessionId, !!prefs.terminalBackgroundImage]);
 
   // Update terminal options when prefs change
   useEffect(() => {

--- a/src/renderer/components/TerminalPane.tsx
+++ b/src/renderer/components/TerminalPane.tsx
@@ -12,6 +12,15 @@ interface TerminalPaneProps {
   onSearchClose?: () => void;
 }
 
+/** Convert a hex color to an rgba() string with the given alpha. */
+function hexToRgba(hex: string, alpha: number): string {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.substring(0, 2), 16);
+  const g = parseInt(h.substring(2, 4), 16);
+  const b = parseInt(h.substring(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 function tryAttachWebgl(terminal: Terminal): { dispose: () => void } | null {
   try {
     const { WebglAddon } = require('@xterm/addon-webgl');
@@ -58,14 +67,20 @@ export default function TerminalPane({ sessionId, visible, searchVisible, onSear
   useEffect(() => {
     if (!containerRef.current) return;
 
+    const hasBackgroundImage = !!prefs.terminalBackgroundImage;
+    const theme = hasBackgroundImage
+      ? { ...prefs.terminalColors, background: hexToRgba(prefs.terminalColors.background || '#000000', 1 - prefs.terminalBackgroundOpacity) }
+      : prefs.terminalColors;
+
     const terminal = new Terminal({
-      theme: prefs.terminalColors,
+      theme,
       fontFamily: prefs.terminalFontFamily,
       fontSize: prefs.terminalFontSize,
       lineHeight: prefs.terminalLineHeight,
       cursorBlink: prefs.cursorBlink,
       scrollback: prefs.scrollbackLines,
       allowProposedApi: true,
+      allowTransparency: hasBackgroundImage,
     });
 
     const fitAddon = new FitAddon();
@@ -74,8 +89,8 @@ export default function TerminalPane({ sessionId, visible, searchVisible, onSear
 
     terminal.open(containerRef.current);
 
-    // Attach WebGL after open
-    webglAddonRef.current = tryAttachWebgl(terminal);
+    // Attach WebGL after open (skip if using background image — WebGL doesn't support transparency)
+    webglAddonRef.current = hasBackgroundImage ? null : tryAttachWebgl(terminal);
 
     // Attach search addon
     searchAddonRef.current = tryAttachSearch(terminal);
@@ -131,7 +146,10 @@ export default function TerminalPane({ sessionId, visible, searchVisible, onSear
   useEffect(() => {
     const terminal = terminalRef.current;
     if (!terminal) return;
-    terminal.options.theme = prefs.terminalColors;
+    const hasBackgroundImage = !!prefs.terminalBackgroundImage;
+    terminal.options.theme = hasBackgroundImage
+      ? { ...prefs.terminalColors, background: hexToRgba(prefs.terminalColors.background || '#000000', 1 - prefs.terminalBackgroundOpacity) }
+      : prefs.terminalColors;
     terminal.options.fontFamily = prefs.terminalFontFamily;
     terminal.options.fontSize = prefs.terminalFontSize;
     terminal.options.lineHeight = prefs.terminalLineHeight;
@@ -146,7 +164,7 @@ export default function TerminalPane({ sessionId, visible, searchVisible, onSear
         // Ignore
       }
     }
-  }, [prefs.terminalColors, prefs.terminalFontFamily, prefs.terminalFontSize, prefs.terminalLineHeight, prefs.cursorBlink, prefs.scrollbackLines, sessionId]);
+  }, [prefs.terminalColors, prefs.terminalFontFamily, prefs.terminalFontSize, prefs.terminalLineHeight, prefs.cursorBlink, prefs.scrollbackLines, prefs.terminalBackgroundImage, prefs.terminalBackgroundOpacity, sessionId]);
 
   // Re-fit, re-attach WebGL, and focus when visibility changes
   useEffect(() => {

--- a/src/renderer/state/preferences.tsx
+++ b/src/renderer/state/preferences.tsx
@@ -18,8 +18,6 @@ function getDefaultPreferences(): SwitchboardPreferences {
     terminalBackgroundImage: null,
     terminalBackgroundOpacity: 0.3,
     sidebarBackgroundImage: null,
-    windowOpacity: 1.0,
-    terminalBackgroundAlpha: 1.0,
     shortcuts: {},
     sessionOrder: [],
     cursorBlink: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -89,8 +89,6 @@ export interface SwitchboardPreferences {
   terminalBackgroundImage: string | null;
   terminalBackgroundOpacity: number;
   sidebarBackgroundImage: string | null;
-  windowOpacity: number;
-  terminalBackgroundAlpha: number;
   shortcuts: Record<string, string>;
   sessionOrder: string[];
   cursorBlink: boolean;
@@ -101,6 +99,10 @@ export interface SwitchboardPreferences {
 /** API exposed by the preload script via contextBridge. */
 export interface SwitchboardAPI {
   platform: NodeJS.Platform;
+  dialog: {
+    openFile(filters?: Array<{ name: string; extensions: string[] }>): Promise<string | null>;
+  };
+  onCycleTab(callback: (shift: boolean) => void): () => void;
   pty: {
     spawn(config: SessionConfig): Promise<SessionInfo>;
     resize(sessionId: string, cols: number, rows: number): Promise<void>;

--- a/tests/helpers/mock-preferences.ts
+++ b/tests/helpers/mock-preferences.ts
@@ -15,8 +15,6 @@ export const mockPrefs = {
   terminalBackgroundImage: null,
   terminalBackgroundOpacity: 0.3,
   sidebarBackgroundImage: null,
-  windowOpacity: 1.0,
-  terminalBackgroundAlpha: 1.0,
   shortcuts: {},
   sessionOrder: [],
   cursorBlink: true,

--- a/tests/main/main.test.ts
+++ b/tests/main/main.test.ts
@@ -12,6 +12,10 @@ vi.mock('electron', () => {
     return {
       loadURL: mockLoadURL,
       loadFile: mockLoadFile,
+      webContents: {
+        on: vi.fn(),
+        send: vi.fn(),
+      },
     };
   });
 

--- a/tests/main/preferences-store.test.ts
+++ b/tests/main/preferences-store.test.ts
@@ -111,8 +111,6 @@ describe('PreferencesStore', () => {
     expect(defaults.terminalBackgroundImage).toBeNull();
     expect(defaults.terminalBackgroundOpacity).toBe(0.3);
     expect(defaults.sidebarBackgroundImage).toBeNull();
-    expect(defaults.windowOpacity).toBe(1.0);
-    expect(defaults.terminalBackgroundAlpha).toBe(1.0);
     expect(defaults.shortcuts).toEqual({});
     expect(defaults.sessionOrder).toEqual([]);
     expect(defaults.cursorBlink).toBe(true);

--- a/tests/renderer/App.test.tsx
+++ b/tests/renderer/App.test.tsx
@@ -17,6 +17,10 @@ vi.mock('@xterm/addon-webgl', () => { throw new Error('No WebGL'); });
 beforeEach(() => {
   (window as any).switchboard = {
     platform: 'linux',
+    dialog: {
+      openFile: vi.fn().mockResolvedValue(null),
+    },
+    onCycleTab: vi.fn().mockReturnValue(() => {}),
     pty: {
       spawn: vi.fn(), resize: vi.fn().mockResolvedValue(undefined),
       close: vi.fn(), input: vi.fn(),


### PR DESCRIPTION
## Summary
- **Ctrl+Tab / Ctrl+Shift+Tab** — intercept via `before-input-event` to bypass Chromium consuming the keypress; forward to renderer via IPC. Tab wrapping works via modulo logic.
- **UI font scaling** — replaced hardcoded `fontSize` in Sidebar, SessionTab, Header, StatusBar with inherited/relative values so `uiFontSize` pref applies everywhere.
- **Transparency removed** — stripped `windowOpacity` and `terminalBackgroundAlpha` prefs and Transparency section from PreferencesModal (broken with xterm WebGL, revisit if requested).
- **File browse dialog** — native Electron file picker for background image selection instead of requiring a typed path.
- **Stale unread badge** — ref + 200ms grace period after tab switch prevents prompt-redraw PTY output from marking sessions as unread.
- **Mouse click tab switching** — added 5px distance activation constraint to dnd-kit PointerSensor so clicks pass through to onSelect.
- **Background images** — terminal: enable `allowTransparency` + rgba theme background + disable WebGL when image is set; recreate terminal when toggled. Sidebar: render the background image layer (was in prefs but never displayed).

## Test plan
- [x] 176 unit tests pass
- [x] TypeScript compiles cleanly
- [x] Manual user testing of all fixes confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)