### PR TITLE
docs(sprints): plan Flow II milestone — sprints 16-18

### DIFF
--- a/sprints/flow-ii/16-queued-prompts.md
+++ b/sprints/flow-ii/16-queued-prompts.md
@@ -1,0 +1,58 @@
+---
+sprint: 16
+title: Queued Prompts
+milestone: Flow II
+status: planned
+---
+
+# Goal
+Let a user pre-stage a prompt for a session. When the session transitions to `needs-attention`, the queued prompt is automatically sent (as if the user typed it and pressed Enter) and cleared. This is the v4 observable: *"Queued prompts: pre-stage a prompt per session; fire it when the session needs attention."*
+
+# Design
+
+## Behavior
+- Each session can have **at most one** queued prompt at a time.
+- Queued prompts are **client-local** — stored per session ID in the renderer state, not sent to the daemon. The client that queued it is the one that fires it. (Rationale: the user who queued it is almost always the one watching for it; avoids races with other connected clients; no protocol change.)
+- Fires **only** on the `idle → needs-attention` transition (not on `working → idle`, not on re-entry to needs-attention if it never went idle in between).
+- **One-shot:** fires once, then the queue is cleared. User must re-queue for the next round.
+- Sent as the prompt text followed by a newline (`\r`), via the existing `pty:input` channel.
+
+## UI
+- A collapsible input bar below each terminal pane (hidden by default, toggled with a small icon in the tab header or a keyboard shortcut — `Ctrl+Shift+Q`; `Ctrl+Q` is reserved as the standard quit shortcut on Linux).
+- Placeholder: "Queue a prompt to send when ready…"
+- When a prompt is queued, the sidebar tab shows a small indicator (e.g. a paper-airplane icon beside the status dot).
+- A "Cancel" button in the queue bar clears without firing.
+
+## Deliverables
+
+### Implementation
+- `src/renderer/state/queued-prompts.tsx` (new) — React context + reducer holding `Map<sessionId, string>`. Actions: `queue(id, text)`, `clear(id)`, `consume(id)` (returns and clears). Persisted to `localStorage` so a brief client restart doesn't lose queued prompts.
+- `src/renderer/components/QueuedPromptBar.tsx` (new) — the input bar component.
+- Update `src/renderer/components/TerminalPane.tsx` — render the bar; own a toggle flag per session.
+- Update `src/renderer/components/SessionTab.tsx` / `SortableSessionTab.tsx` — show the queued indicator.
+- Update `src/renderer/hooks/useKeyboardShortcuts.ts` — add `Ctrl+Shift+Q` to toggle the queue bar.
+- Hook into session status changes: when a session's status transitions to `needs-attention` AND it has a queued prompt, send the prompt via `window.switchboard.pty.input(id, text + '\r')` and consume.
+
+### Specs
+- `specs/src/renderer/state/queued-prompts-spec.md`
+- Update existing component specs (TerminalPane, SessionTab) to note the new integration.
+
+### Tests
+- `tests/renderer/state/queued-prompts.test.tsx` — reducer/actions, localStorage round-trip.
+- `tests/renderer/components/QueuedPromptBar.test.tsx` — input, submit, clear.
+- Integration test: status transition triggers fire + consume.
+
+# Acceptance Criteria
+- User can toggle the queue bar on a session, type a prompt, and press Enter (or a "Queue" button) to stage it.
+- When the session goes `needs-attention`, the queued prompt is sent and the queue is cleared.
+- Sidebar tab shows a queued-prompt indicator while a prompt is staged.
+- Queue bar toggle is bound to `Ctrl+Shift+Q` (overrideable in shortcuts prefs).
+- Queued prompts survive a renderer hot-reload / brief client restart (via localStorage).
+- All tests pass.
+
+# Dependencies
+- Daemon (v3) — uses existing `session:status` broadcast and `pty:input` IPC.
+
+# Notes
+- Firing on `needs-attention` means the prompt goes in as soon as Claude Code (or another agent) stops and waits for input. That's the intended workflow.
+- Client-local queue is a deliberate v4 scope choice. If multiple clients are watching the same session and both have queued prompts, whichever fires first wins. If daemon-side queueing is needed later, the protocol can add a `session:queue-prompt` message and the state can migrate.

--- a/sprints/flow-ii/17-tray-and-notifications.md
+++ b/sprints/flow-ii/17-tray-and-notifications.md
@@ -1,0 +1,79 @@
+---
+sprint: 17
+title: System Tray & Notification Routing
+milestone: Flow II
+status: planned
+---
+
+# Goal
+Bring Switchboard's attention-awareness outside the main window. A system-tray icon shows the total count of sessions needing attention across all daemons; clicking it restores focus. Per-session notification priority lets the user mute noisy sessions or escalate important ones. Covers two v4 observables: tray with unread badge, and notification routing (high/normal/silent).
+
+# Design
+
+## System Tray
+
+### Behavior
+- Tray icon appears on app startup; persists across window close (window close hides, doesn't quit).
+- Icon shows a numeric badge with the count of sessions currently in `needs-attention` across all connected daemons.
+- Left-click tray: show the main window and focus the most recently attention-needing session (or the active session if none are needs-attention).
+- Right-click tray: context menu with entries:
+  - "Show Switchboard" / "Hide Switchboard"
+  - Per-daemon status lines (e.g. "Localhost — 2 sessions, 1 need attention")
+  - "Quit"
+- On Linux, the tray icon uses the standard `app.setAppUserModelId` + `Tray` API. macOS-style menubar rendering is out of scope for this sprint (future v5 concern).
+
+### Implementation
+- `src/main/tray.ts` (new) — owns the `Tray` instance, renders the icon with count overlay.
+- Update `src/main/main.ts` — instantiate tray, wire to window close ("hide instead of quit"), wire to daemon status events.
+- The tray queries `connectionManager.getConnectionStatuses()` and aggregates attention counts. Listens to existing `session:status-changed` broadcasts.
+
+## Notification Routing
+
+### Behavior
+- Each session can be tagged with a notification priority: `high`, `normal`, `silent`.
+- Defaults to `normal` (the existing behavior).
+- `high`: always fires the OS notification, even when the app is focused.
+- `normal`: fires when the app is not focused (current behavior).
+- `silent`: never fires the OS notification, but still updates tab status + tray count.
+- Priority is set via the existing session context-menu (right-click on tab → "Notifications" submenu).
+- Stored per session ID in preferences (keyed by the composite `daemonId:sessionId` when applicable).
+
+### Implementation
+- Extend `SwitchboardPreferences` with `notificationPriorities: Record<string, 'high' | 'normal' | 'silent'>`.
+- Update `src/renderer/components/ContextMenu.tsx` — add "Notifications" submenu with the three options.
+- Update `src/main/connection-manager.ts` and (for localhost-local) `src/main/notifications.ts` — consult the priority map before firing. Need a way for the main-process notification code to read the priority; easiest is an IPC call or a subscription on preference changes.
+
+## Deliverables
+
+### Implementation
+- `src/main/tray.ts`
+- Update `src/main/main.ts`, `src/main/connection-manager.ts`, `src/main/notifications.ts`
+- Update `src/renderer/components/ContextMenu.tsx`
+- Update `src/shared/types.ts` — add `notificationPriorities` to prefs; add `window.switchboard.session.setPriority(...)` to the API.
+- Update `src/main/preload.ts` — expose the new IPC.
+
+### Tests
+- `tests/main/tray.test.ts` — badge count calculation, menu contents, icon updates on status change.
+- `tests/main/notifications.test.ts` — extend with priority filtering.
+- `tests/renderer/ContextMenu.test.tsx` — new submenu entries.
+
+### Specs
+- `specs/src/main/tray-spec.md`
+- Update `specs/src/main/notifications-spec.md`
+- Update `specs/src/main/connection-manager-spec.md`
+
+# Acceptance Criteria
+- Tray icon shows total `needs-attention` count across all daemons, updates live.
+- Left-click tray restores the main window and focuses an attention-needing session.
+- Closing the main window hides it to tray; app continues running.
+- User can right-click a session tab → Notifications → Silent and receive no OS notifications from that session.
+- `high`-priority sessions fire notifications even when the window is focused.
+- Priorities persist across client restarts.
+- All tests pass.
+
+# Dependencies
+- Sprint 16 (queued prompts) — independent, but scheduling Sprint 17 after gives both features a shared touch on the session-status event path.
+
+# Notes
+- Minimize-to-tray behavior: on window-close, hide instead of quit. An explicit "Quit" from tray or `Cmd+Q` shuts down the app.
+- The tray API differs subtly across platforms; we target Linux first (the dev platform). macOS/Windows behaviors to be validated when packaging for those targets.

--- a/sprints/flow-ii/18-sidebar-organization.md
+++ b/sprints/flow-ii/18-sidebar-organization.md
@@ -1,0 +1,76 @@
+---
+sprint: 18
+title: Session Groups & Templates
+milestone: Flow II
+status: planned
+---
+
+# Goal
+Make the sidebar scalable when the user has many sessions across many hosts. Two related features: **session templates** (save a reusable session config for one-click spawn) and **session groups** (collapsible sidebar headers organizing sessions by host, project, or user-defined grouping). Covers two v4 observables.
+
+# Design
+
+## Session Templates
+
+### Behavior
+- A template stores: name, host (daemon id), cwd, command (optional).
+- Templates are managed from the New Session modal:
+  - A "Save as template" checkbox on session-creation.
+  - A "Templates" dropdown at the top of the modal: picking a template prefills the form.
+  - A "Manage templates" link opens a small list/edit dialog.
+- Templates live in `SwitchboardPreferences.sessionTemplates: SessionTemplate[]`.
+
+### Implementation
+- Extend `src/shared/types.ts` — `SessionTemplate` type and `sessionTemplates` prefs field.
+- Update `src/renderer/components/NewSessionModal.tsx` — template dropdown + save checkbox.
+- `src/renderer/components/ManageTemplatesModal.tsx` (new) — list, edit, delete templates.
+
+## Session Groups
+
+### Behavior
+- Sessions are displayed under collapsible group headers in the sidebar.
+- Default grouping: **by host** (daemon name). Each daemon's sessions collapse under its name.
+- User can override group for a session via context menu → "Move to group…" → pick/create.
+- Collapsed/expanded state is persisted per group.
+- Sessions without an explicit group appear under their host group. Ungrouping a session returns it to the host default.
+- Drag-and-drop reordering still works within a group.
+
+### Implementation
+- Extend `SwitchboardPreferences`:
+  - `sessionGroups: Record<string, { name: string; collapsed: boolean; sessionIds: string[] }>`
+  - Implicit host-default groups use `daemon-<daemonId>` as the group key.
+- Update `src/renderer/components/Sidebar.tsx` — render groups, expand/collapse toggles, group headers.
+- Update `src/renderer/components/ContextMenu.tsx` — "Move to group" submenu.
+- Drag-and-drop: reordering within a group updates that group's `sessionIds`; dragging across groups moves the session.
+
+## Deliverables
+
+### Implementation
+- `src/renderer/components/ManageTemplatesModal.tsx`
+- Update `src/renderer/components/NewSessionModal.tsx`, `Sidebar.tsx`, `ContextMenu.tsx`
+- Update `src/shared/types.ts` — new template + group types and prefs fields
+
+### Tests
+- `tests/renderer/components/ManageTemplatesModal.test.tsx`
+- Update `NewSessionModal.test.tsx`, `Sidebar.test.tsx` (if exists), `ContextMenu.test.tsx`
+
+### Specs
+- `specs/src/renderer/components/ManageTemplatesModal-spec.md`
+- Update Sidebar and ContextMenu specs
+
+# Acceptance Criteria
+- User can create a session from a saved template in one click.
+- User can save a new template from the New Session modal.
+- Sidebar groups sessions by host by default; headers are collapsible.
+- Collapsed/expanded state persists across restarts.
+- User can move a session to a custom-named group via context menu.
+- Drag-and-drop reordering respects groups.
+- All tests pass.
+
+# Dependencies
+- Sprint 16 (queued prompts) and Sprint 17 (tray & notifications) — independent work, but this sprint closes out Flow II.
+
+# Notes
+- Session templates are a small feature bundled into this sprint because they overlap with the New Session modal and sit next to the "organize your sessions" theme.
+- Groups are more involved — most of the sprint's complexity lives in the sidebar rendering and drag-and-drop rules.
+- Flow II completes when this sprint merges.


### PR DESCRIPTION
## Summary

Three sprint plans for the v4 Flow II milestone.

- **Sprint 16** — Queued prompts: pre-stage a prompt per session; auto-fire on \`idle → needs-attention\` transition. Client-local storage; Ctrl+Shift+Q toggles the queue bar.
- **Sprint 17** — System tray + notification routing: tray icon with attention-count badge, per-session priority (high/normal/silent), window-close hides to tray.
- **Sprint 18** — Session groups + templates: sidebar collapsible groups (by-host default), saved session templates for one-click spawn.

## Key design decisions

- Queued prompts are **client-local** (simpler, no protocol change; multi-client races accepted as scope call)
- Queued prompts fire **on status transition only** (not on re-entry into needs-attention)
- Tray is **Linux-first**; macOS/Windows validated when packaging for those
- Notification priorities stored in \`preferences.json\` keyed by composite session id

No code changes in this PR — planning only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)