### PR TITLE
fix(client): hydrate sessions on mount to fix IPC race (rc.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.4.0-rc.5",
+  "version": "0.4.0-rc.6",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -79,11 +79,23 @@ function AppContent(): React.ReactElement {
     return unsubStatus;
   }, [updateSessionStatus]);
 
-  // Listen for daemon-created sessions (async spawn via daemon)
+  // Listen for daemon-created sessions (async spawn via daemon).
+  // Also hydrate from main's current session list to recover from any
+  // session-created broadcasts that fired before this listener attached.
   useEffect(() => {
+    const knownIds = new Set<string>();
     const unsub = window.switchboard.session.onSessionCreated((session: import('../shared/types').SessionInfo) => {
+      if (knownIds.has(session.id)) return;
+      knownIds.add(session.id);
       addSession(session);
     });
+    window.switchboard.session.list().then((sessions: import('../shared/types').SessionInfo[]) => {
+      for (const session of sessions) {
+        if (knownIds.has(session.id)) continue;
+        knownIds.add(session.id);
+        addSession(session);
+      }
+    }).catch(() => {});
     return unsub;
   }, [addSession]);
 

--- a/tests/renderer/App.test.tsx
+++ b/tests/renderer/App.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock xterm.js
@@ -8,6 +8,7 @@ vi.mock('@xterm/xterm', () => ({
     loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(),
     onData: vi.fn().mockReturnValue({ dispose: vi.fn() }),
     dispose: vi.fn(), focus: vi.fn(), cols: 80, rows: 24,
+    options: {},
   })),
 }));
 vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn().mockImplementation(() => ({ fit: vi.fn(), dispose: vi.fn() })) }));
@@ -92,5 +93,31 @@ describe('App', () => {
   it('renders a New Session button', () => {
     render(<App />);
     expect(screen.getByTestId('new-session-button')).toBeInTheDocument();
+  });
+
+  it('hydrates existing daemon sessions via session.list on mount', async () => {
+    (window as any).switchboard.session.list = vi.fn().mockResolvedValue([
+      { id: 'vm:abc', name: 'tick-loop', status: 'working', cwd: '/home/x', command: 'bash' },
+    ]);
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByTestId('session-tab-vm:abc')).toBeInTheDocument();
+    });
+  });
+
+  it('deduplicates sessions across list-hydration and create-broadcast', async () => {
+    const session = { id: 'vm:abc', name: 'shared', status: 'working', cwd: '/home/x', command: 'bash' };
+    let createdHandler: ((s: any) => void) | null = null;
+    (window as any).switchboard.session.list = vi.fn().mockResolvedValue([session]);
+    (window as any).switchboard.session.onSessionCreated = vi.fn().mockImplementation((cb: any) => {
+      createdHandler = cb;
+      return () => {};
+    });
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByTestId('session-tab-vm:abc')).toBeInTheDocument();
+    });
+    createdHandler?.(session);
+    expect(screen.getAllByTestId('session-tab-vm:abc')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- Renderer now calls \`session.list()\` on mount instead of relying on broadcast-only delivery
- Local Set dedupes hydrated sessions against late-arriving \`session:created\` broadcasts
- Bumps version to 0.4.0-rc.6

## The bug
On reopen, daemon sessions appeared in the New Session modal's count (\"VM (1 sessions)\") but no tab showed in the sidebar — the session was unreachable.

The renderer subscribes to \`onSessionCreated\` in a \`useEffect\` that runs after first render. Main's connection-manager broadcasts \`daemon:session-created\` for each session as soon as the daemon sends \`auth:ok\` + \`session:list\`. Electron's \`webContents.send\` has no buffering, so events broadcast before the listener attached were silently dropped. The IPC handler \`session:list\` and preload binding \`window.switchboard.session.list()\` already existed in main — but were never called.

## Known gap (out of scope)
Replay buffer for pre-existing sessions is still missing. The daemon's \`replay:*\` flow only fires once per WS connect and is not requestable. A new \`session:replay-request\` protocol message will ship with Issue #32 (persistent daemon + session restore).

## Test plan
- [x] 8/8 App tests pass (added 2 new: hydration + dedup)
- [x] 254/254 full suite passes
- [ ] Manual: connect to remote daemon with existing session, close client, reopen — tab appears in sidebar
- [ ] Manual: rapid-fire spawn while session.list() is in flight — no duplicate tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)