### PR TITLE
docs(state): Sprint 17 merged, Sprint 18 next

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -4,10 +4,11 @@
 Switchboard is a Slack-style multi-session terminal manager built for developers who run AI coding agents in parallel. Electron desktop app with React UI, xterm.js terminals. PTYs run on a standalone daemon process; the Electron client is a daemon client. Repository: `gits/switchboard`. Current phase: **Daemon (v3) complete — between milestones**.
 
 ## Active Work
-- **Milestone:** Flow II (v4) — Sprint 16 complete, planning to pull Issue #32 ahead of Sprint 17.
-- **Next up:** Issue #32 (persistent daemon: session restore on startup + user-level systemd service). Replay-buffer-history gap from PR #34 shares the same `session:replay-request` protocol surface. Sprints 17 (Tray & Notifications) and 18 (Templates & Groups) follow.
+- **Milestone:** Flow II (v4) — Sprint 17 complete (Part 1 of Issue #32). Sprint 18 next: user-level systemd service installer (Part 2 of Issue #32).
+- **Next up:** Sprint 18 (systemd user service), then Sprint 19 (Tray & Notifications), Sprint 20 (Templates & Groups).
 
 ## Recent Completions
+- Sprint 17: Persistent daemon — boot-time session restore (stable ids across restart) + on-demand replay via `session:replay-request`. Closes Part 1 of Issue #32 and the rc.6 replay-history gap. Live-verified on VM: session respawned with same id after SIGTERM/restart, sidebar tab hydrated, idle indicator correct. PR #36 merged — 2026-05-22.
 - Session-list IPC race fix (rc.6) — daemon-side sessions now hydrate as sidebar tabs on client open via `session.list()` poll alongside the broadcast subscription. Replay history for pre-existing sessions still missing — rolls into #32. PR #34 merged — 2026-05-01.
 - Sprint 16: Queued Prompts — daemon-side queue with strict 0/1 per session, broadcast-to-all + reject-only-to-requester, persists to disk, fires on `needs-attention`. Idle-detector default regex relaxed (drop `^` anchor). PR #33 merged — 2026-04-30.
 - Flow II planning — sprint files for 16/17/18 staged. PR #31 merged — 2026-04-23.
@@ -58,8 +59,8 @@ Switchboard is a Slack-style multi-session terminal manager built for developers
 - `src/shared/` — types.ts, themes.ts, protocol.ts.
 - `src/daemon/` — Standalone daemon: daemon.ts (entry), config.ts, pty-manager.ts, idle-detector.ts, output-buffer.ts, session-store.ts, transport.ts, auth.ts.
 - `sprints/daemon/` — 4 sprint files (12–15), all complete.
-- `sprints/flow-ii/` — 3 sprint files (16–18); 16 complete, 17–18 planned.
-- `tests/` — 31 test files, 254 tests passing.
+- `sprints/flow-ii/` — 5 sprint files (16–20); 16–17 complete, 18–20 planned.
+- `tests/` — 32 test files, 262 tests passing.
 
 ## Key Decisions
 - DEC-000001: Retire v3 Intelligence; introduce v3 Daemon, v4 Flow II, v5 Intelligence. Daemon-first architecture to support remote sessions and session mobility.
@@ -68,8 +69,6 @@ Switchboard is a Slack-style multi-session terminal manager built for developers
 *(none)*
 
 ## Session Notes
-Daemon (v3) complete and live-verified. Flow II (v4) underway: Sprint 16 (Queued Prompts) shipped daemon-side, broadcast-to-all + reject-only-to-requester with strict 0/1 per session, persisted to disk. Pivoted from initial client-local design after user identified cross-device + client-restart-continuity gaps in testing.
+Daemon (v3) complete and live-verified. Flow II (v4) underway. Sprint 16 (Queued Prompts) shipped daemon-side with broadcast-to-all + reject-only-to-requester semantics. Sprint 17 (Persistent Daemon — Part 1 of Issue #32) shipped: boot-time restore reconstructs sessions from `sessions.json` with stable ids so per-session buffer paths remain valid across restart; `session:replay-request` is a new client→daemon message the renderer fires on mount, closing the rc.6 replay-history gap for pre-existing sessions. Note: PTYs themselves don't survive daemon restart — only metadata + scrollback do; respawned sessions get a fresh shell.
 
-PR #34 (rc.6) fixed an IPC race where existing daemon sessions didn't hydrate as sidebar tabs on client open — `session:list` broadcast fired before renderer's listener attached. Renderer now polls `session.list()` on mount in addition to subscribing. Replay-buffer history for pre-existing sessions is still missing — daemon's `replay:*` only fires once per WS connect and is not re-requestable. That gap rolls into Issue #32, which is being pulled ahead of Sprint 17.
-
-ROADMAP.md milestone 4 observables: queued prompts ✅, system tray (Sprint 17), templates + groups (Sprint 18), notification routing.
+ROADMAP.md milestone 4 observables: queued prompts ✅, persistent daemon (Sprint 17 ✅, systemd installer Sprint 18), system tray (Sprint 19), templates + groups (Sprint 20), notification routing.

--- a/STATE.md
+++ b/STATE.md
@@ -66,7 +66,7 @@ Switchboard is a Slack-style multi-session terminal manager built for developers
 - DEC-000001: Retire v3 Intelligence; introduce v3 Daemon, v4 Flow II, v5 Intelligence. Daemon-first architecture to support remote sessions and session mobility.
 
 ## Open Questions
-*(none)*
+- Issue #38: `OutputBuffer` line-based storage corrupts PTY byte streams — replay-on-demand is broken for TUI output (watch/vim/less/claude). Three compounding bugs: split/join injects spurious newlines at chunk boundaries, line-eviction strips initial state-setting escape codes, and replay races with live `session:data`. Fix is a byte-based buffer + renderer-side replay queue — sized as its own sprint. Queued post-Sprint 18.
 
 ## Session Notes
 Daemon (v3) complete and live-verified. Flow II (v4) underway. Sprint 16 (Queued Prompts) shipped daemon-side with broadcast-to-all + reject-only-to-requester semantics. Sprint 17 (Persistent Daemon — Part 1 of Issue #32) shipped: boot-time restore reconstructs sessions from `sessions.json` with stable ids so per-session buffer paths remain valid across restart; `session:replay-request` is a new client→daemon message the renderer fires on mount, closing the rc.6 replay-history gap for pre-existing sessions. Note: PTYs themselves don't survive daemon restart — only metadata + scrollback do; respawned sessions get a fresh shell.


### PR DESCRIPTION
## Summary
- Move Sprint 17 to Recent Completions with live-verification note
- Set Sprint 18 (systemd user service installer) as next up
- Refresh sprint count (5 files), test count (262), and milestone-4 observables

## Test plan
- [ ] Review STATE.md renders correctly
🤖 Generated with [Claude Code](https://claude.com/claude-code)