### PR TITLE
Sprint 18: systemd user service installer (rc.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.4.0-rc.7",
+  "version": "0.4.0-rc.8",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,6 +1,8 @@
 import { ipcMain, BrowserWindow, dialog } from 'electron';
 import { PreferencesStore } from './preferences-store';
 import { ConnectionManager, type DaemonConnectionConfig } from './connection-manager';
+import type { LocalDaemon } from './local-daemon';
+import * as systemd from './systemd-installer';
 import type { SwitchboardPreferences } from '../shared/types';
 
 function broadcast(channel: string, data: unknown): void {
@@ -10,7 +12,10 @@ function broadcast(channel: string, data: unknown): void {
   }
 }
 
-export function registerIpcHandlers(connectionManager: ConnectionManager): void {
+export function registerIpcHandlers(
+  connectionManager: ConnectionManager,
+  localDaemon?: LocalDaemon,
+): void {
   const preferencesStore = new PreferencesStore();
 
   // --- Session commands (all route to daemon) ---
@@ -133,6 +138,49 @@ export function registerIpcHandlers(connectionManager: ConnectionManager): void 
     const defaults = preferencesStore.reset();
     broadcast('preferences:changed', defaults);
     return defaults;
+  });
+
+  // --- Localhost daemon service (systemd --user) ---
+
+  ipcMain.handle('localService:status', async () => {
+    return systemd.getStatus();
+  });
+
+  ipcMain.handle('localService:install', async () => {
+    if (!localDaemon) throw new Error('Local daemon not available');
+    if (!systemd.isSupported()) {
+      throw new Error('Service install is only supported on Linux');
+    }
+    const daemonScript = localDaemon.getDaemonScriptPath();
+    await systemd.install({
+      daemonScript,
+      execBinary: process.execPath,
+      electronAsNode: true,
+    });
+    return systemd.getStatus();
+  });
+
+  ipcMain.handle('localService:uninstall', async () => {
+    if (!systemd.isSupported()) {
+      throw new Error('Service install is only supported on Linux');
+    }
+    await systemd.uninstall();
+    return systemd.getStatus();
+  });
+
+  ipcMain.handle('localService:start', async () => {
+    await systemd.start();
+    return systemd.getStatus();
+  });
+
+  ipcMain.handle('localService:stop', async () => {
+    await systemd.stop();
+    return systemd.getStatus();
+  });
+
+  ipcMain.handle('localService:restart', async () => {
+    await systemd.restart();
+    return systemd.getStatus();
   });
 
   // --- Dialog ---

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -143,13 +143,30 @@ export function registerIpcHandlers(
   // --- Localhost daemon service (systemd --user) ---
 
   ipcMain.handle('localService:status', async () => {
-    return systemd.getStatus();
+    const status = await systemd.getStatus();
+    if (process.env.APPIMAGE) {
+      return {
+        ...status,
+        installBlocked: true,
+        installBlockedReason:
+          'Service install is not supported when running from an AppImage. ' +
+          'Install Switchboard from .deb or .snap, or run from source.',
+      };
+    }
+    return status;
   });
 
   ipcMain.handle('localService:install', async () => {
     if (!localDaemon) throw new Error('Local daemon not available');
     if (!systemd.isSupported()) {
       throw new Error('Service install is only supported on Linux');
+    }
+    if (process.env.APPIMAGE) {
+      throw new Error(
+        'Service install is not supported when running from an AppImage. ' +
+        'Install Switchboard from .deb, .snap, or run from source. ' +
+        '(AppImages live at ephemeral mount paths that systemd cannot resolve after the GUI exits.)'
+      );
     }
     // Free port 3717 before systemctl enable --now spawns the service-managed daemon.
     await localDaemon.stopChildAndWait();

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -151,12 +151,15 @@ export function registerIpcHandlers(
     if (!systemd.isSupported()) {
       throw new Error('Service install is only supported on Linux');
     }
+    // Free port 3717 before systemctl enable --now spawns the service-managed daemon.
+    await localDaemon.stopChildAndWait();
     const daemonScript = localDaemon.getDaemonScriptPath();
     await systemd.install({
       daemonScript,
       execBinary: process.execPath,
       electronAsNode: true,
     });
+    localDaemon.markServiceManaged();
     return systemd.getStatus();
   });
 

--- a/src/main/local-daemon.ts
+++ b/src/main/local-daemon.ts
@@ -5,14 +5,35 @@ import * as os from 'os';
 import * as crypto from 'crypto';
 import { app } from 'electron';
 import type { DaemonConnectionConfig } from '../shared/types';
+import * as systemd from './systemd-installer';
 
 export const LOCALHOST_DAEMON_ID = 'localhost';
 
 export class LocalDaemon {
   private process: ChildProcess | null = null;
   private stderrBuffer = '';
+  private serviceManaged = false;
 
   async start(): Promise<DaemonConnectionConfig> {
+    // If a systemd user service is installed and running, defer to it instead
+    // of spawning a child. The client just connects to the existing daemon.
+    if (systemd.isSupported() && systemd.isInstalled()) {
+      const running = await systemd.isRunning();
+      if (running) {
+        this.serviceManaged = true;
+        const config = this.readDaemonConfig();
+        return {
+          id: LOCALHOST_DAEMON_ID,
+          name: 'Localhost',
+          host: '127.0.0.1',
+          port: config.port,
+          token: config.auth.token,
+          fingerprint: config.fingerprint,
+          autoConnect: true,
+        };
+      }
+    }
+
     const daemonScript = this.resolveDaemonScript();
 
     if (!fs.existsSync(daemonScript)) {
@@ -50,11 +71,25 @@ export class LocalDaemon {
     };
   }
 
+  /**
+   * Whether the localhost daemon is managed by an external systemd service
+   * (i.e., this instance did not spawn the daemon child).
+   */
+  isServiceManaged(): boolean {
+    return this.serviceManaged;
+  }
+
+  /** Absolute path to the daemon entry script for the current build. */
+  getDaemonScriptPath(): string {
+    return this.resolveDaemonScript();
+  }
+
   stop(): void {
     if (this.process) {
       this.process.kill('SIGTERM');
       this.process = null;
     }
+    // Service-managed daemons are intentionally left running on app quit.
   }
 
   private resolveDaemonScript(): string {

--- a/src/main/local-daemon.ts
+++ b/src/main/local-daemon.ts
@@ -79,9 +79,30 @@ export class LocalDaemon {
     return this.serviceManaged;
   }
 
+  /** Mark the localhost daemon as service-managed (called after a successful install). */
+  markServiceManaged(): void {
+    this.serviceManaged = true;
+  }
+
   /** Absolute path to the daemon entry script for the current build. */
   getDaemonScriptPath(): string {
     return this.resolveDaemonScript();
+  }
+
+  /**
+   * Stop the child daemon if we spawned one and wait for the OS to release the port.
+   * No-op if service-managed or no child exists.
+   */
+  async stopChildAndWait(): Promise<void> {
+    if (!this.process || this.serviceManaged) return;
+    const proc = this.process;
+    this.process = null;
+    await new Promise<void>((resolve) => {
+      const done = () => resolve();
+      proc.once('exit', done);
+      proc.kill('SIGTERM');
+      setTimeout(done, 3000);
+    });
   }
 
   stop(): void {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -52,7 +52,7 @@ app.whenReady().then(async () => {
     console.error('Failed to auto-start localhost daemon:', err);
   }
 
-  registerIpcHandlers(connectionManager);
+  registerIpcHandlers(connectionManager, localDaemon);
   mainWindow = createWindow();
 
   mainWindow.webContents.on('before-input-event', (event, input) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -148,6 +148,26 @@ const api = {
       ipcRenderer.on('daemon:pair-failed', handler);
       return () => ipcRenderer.removeListener('daemon:pair-failed', handler);
     },
+    localService: {
+      status() {
+        return ipcRenderer.invoke('localService:status');
+      },
+      install() {
+        return ipcRenderer.invoke('localService:install');
+      },
+      uninstall() {
+        return ipcRenderer.invoke('localService:uninstall');
+      },
+      start() {
+        return ipcRenderer.invoke('localService:start');
+      },
+      stop() {
+        return ipcRenderer.invoke('localService:stop');
+      },
+      restart() {
+        return ipcRenderer.invoke('localService:restart');
+      },
+    },
   },
   preferences: {
     load() {

--- a/src/main/systemd-installer.ts
+++ b/src/main/systemd-installer.ts
@@ -27,6 +27,10 @@ export interface ServiceStatus {
   installed: boolean;
   running: boolean;
   pid?: number;
+  /** True when the host environment cannot support install (e.g., AppImage). */
+  installBlocked?: boolean;
+  /** Human-readable explanation of why install is blocked. */
+  installBlockedReason?: string;
 }
 
 export interface InstallParams {

--- a/src/main/systemd-installer.ts
+++ b/src/main/systemd-installer.ts
@@ -1,0 +1,164 @@
+import * as cp from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+type ExecRunner = (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+
+const defaultRunner: ExecRunner = (cmd, args) =>
+  new Promise((resolve, reject) => {
+    cp.execFile(cmd, args, (err, stdout, stderr) => {
+      if (err) reject(err);
+      else resolve({ stdout, stderr });
+    });
+  });
+
+let execFileAsync: ExecRunner = defaultRunner;
+
+/** Test seam: replace the systemctl runner. Pass undefined to reset to default. */
+export function __setRunner(runner: ExecRunner | undefined): void {
+  execFileAsync = runner ?? defaultRunner;
+}
+
+export const SERVICE_NAME = 'switchboard-daemon';
+const UNIT_FILENAME = `${SERVICE_NAME}.service`;
+
+export interface ServiceStatus {
+  installed: boolean;
+  running: boolean;
+  pid?: number;
+}
+
+export interface InstallParams {
+  /** Absolute path to the daemon entry script (daemon.js). */
+  daemonScript: string;
+  /** Node/Electron binary that will execute the script. */
+  execBinary: string;
+  /** If true, set ELECTRON_RUN_AS_NODE=1 (required when execBinary is Electron). */
+  electronAsNode: boolean;
+  /** Optional SWITCHBOARD_HOME override; defaults to ~/.switchboard. */
+  dataDir?: string;
+}
+
+function unitFilePath(): string {
+  return path.join(os.homedir(), '.config', 'systemd', 'user', UNIT_FILENAME);
+}
+
+export function isSupported(): boolean {
+  return process.platform === 'linux';
+}
+
+export function isInstalled(): boolean {
+  return fs.existsSync(unitFilePath());
+}
+
+export async function isRunning(): Promise<boolean> {
+  try {
+    await execFileAsync('systemctl', ['--user', 'is-active', SERVICE_NAME]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getMainPid(): Promise<number | undefined> {
+  try {
+    const { stdout } = await execFileAsync('systemctl', [
+      '--user',
+      'show',
+      SERVICE_NAME,
+      '--property=MainPID',
+      '--value',
+    ]);
+    const pid = parseInt(stdout.trim(), 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function getStatus(): Promise<ServiceStatus> {
+  if (!isSupported()) return { installed: false, running: false };
+  const installed = isInstalled();
+  if (!installed) return { installed: false, running: false };
+  const running = await isRunning();
+  const pid = running ? await getMainPid() : undefined;
+  return { installed, running, pid };
+}
+
+export function renderUnitFile(params: InstallParams): string {
+  const { daemonScript, execBinary, electronAsNode, dataDir } = params;
+  const envLines: string[] = [];
+  if (electronAsNode) envLines.push('Environment=ELECTRON_RUN_AS_NODE=1');
+  if (dataDir) envLines.push(`Environment=SWITCHBOARD_HOME=${dataDir}`);
+
+  return [
+    '[Unit]',
+    'Description=Switchboard daemon',
+    'After=default.target',
+    '',
+    '[Service]',
+    'Type=simple',
+    `ExecStart=${execBinary} ${daemonScript}`,
+    'Restart=on-failure',
+    'RestartSec=2',
+    ...envLines,
+    '',
+    '[Install]',
+    'WantedBy=default.target',
+    '',
+  ].join('\n');
+}
+
+export async function install(params: InstallParams): Promise<void> {
+  if (!isSupported()) throw new Error('systemd user service is Linux-only');
+  if (!path.isAbsolute(params.daemonScript)) {
+    throw new Error('daemonScript must be absolute');
+  }
+  if (!path.isAbsolute(params.execBinary)) {
+    throw new Error('execBinary must be absolute');
+  }
+  if (!fs.existsSync(params.daemonScript)) {
+    throw new Error(`daemon script not found: ${params.daemonScript}`);
+  }
+
+  const unitPath = unitFilePath();
+  fs.mkdirSync(path.dirname(unitPath), { recursive: true });
+  fs.writeFileSync(unitPath, renderUnitFile(params), 'utf-8');
+
+  await execFileAsync('systemctl', ['--user', 'daemon-reload']);
+  await execFileAsync('systemctl', ['--user', 'enable', '--now', SERVICE_NAME]);
+}
+
+export async function uninstall(): Promise<void> {
+  if (!isSupported()) throw new Error('systemd user service is Linux-only');
+  try {
+    await execFileAsync('systemctl', ['--user', 'disable', '--now', SERVICE_NAME]);
+  } catch {
+    // Service may not be enabled / running; continue
+  }
+  const unitPath = unitFilePath();
+  if (fs.existsSync(unitPath)) fs.unlinkSync(unitPath);
+  try {
+    await execFileAsync('systemctl', ['--user', 'daemon-reload']);
+  } catch {
+    // daemon-reload after removal is best-effort
+  }
+}
+
+export async function start(): Promise<void> {
+  if (!isSupported()) throw new Error('systemd user service is Linux-only');
+  await execFileAsync('systemctl', ['--user', 'start', SERVICE_NAME]);
+}
+
+export async function stop(): Promise<void> {
+  if (!isSupported()) throw new Error('systemd user service is Linux-only');
+  await execFileAsync('systemctl', ['--user', 'stop', SERVICE_NAME]);
+}
+
+export async function restart(): Promise<void> {
+  if (!isSupported()) throw new Error('systemd user service is Linux-only');
+  await execFileAsync('systemctl', ['--user', 'restart', SERVICE_NAME]);
+}
+
+export const __testing__ = { unitFilePath };

--- a/src/renderer/components/PreferencesModal.tsx
+++ b/src/renderer/components/PreferencesModal.tsx
@@ -30,6 +30,8 @@ interface LocalServiceStatus {
   installed: boolean;
   running: boolean;
   pid?: number;
+  installBlocked?: boolean;
+  installBlockedReason?: string;
 }
 
 function LocalServiceSection({ uiColors, labelStyle }: {
@@ -91,14 +93,18 @@ function LocalServiceSection({ uiColors, labelStyle }: {
           <span style={{ fontSize: 12, color: uiColors.appTextMuted }}>Checking…</span>
         ) : !status.installed ? (
           <>
-            <span style={{ flex: 1, fontSize: 13, color: uiColors.appText }}>Not installed</span>
-            <button
-              data-testid="local-service-install"
-              onClick={() => run(() => window.switchboard.daemon.localService.install(),
-                'Install Switchboard daemon as a systemd user service?\n\nThe daemon will auto-start on login and survive client restarts.')}
-              disabled={busy}
-              style={btn}
-            >Install</button>
+            <span style={{ flex: 1, fontSize: 13, color: uiColors.appText }}>
+              {status.installBlocked ? 'Install unavailable' : 'Not installed'}
+            </span>
+            {!status.installBlocked && (
+              <button
+                data-testid="local-service-install"
+                onClick={() => run(() => window.switchboard.daemon.localService.install(),
+                  'Install Switchboard daemon as a systemd user service?\n\nThe daemon will auto-start on login and survive client restarts.')}
+                disabled={busy}
+                style={btn}
+              >Install</button>
+            )}
           </>
         ) : status.running ? (
           <>
@@ -143,6 +149,11 @@ function LocalServiceSection({ uiColors, labelStyle }: {
       </div>
       {error && (
         <div style={{ color: uiColors.errorText, fontSize: 12, marginTop: 6 }}>{error}</div>
+      )}
+      {status?.installBlocked && status.installBlockedReason && (
+        <div style={{ color: uiColors.appTextMuted, fontSize: 11, marginTop: 6, fontStyle: 'italic' }}>
+          {status.installBlockedReason}
+        </div>
       )}
     </div>
   );

--- a/src/renderer/components/PreferencesModal.tsx
+++ b/src/renderer/components/PreferencesModal.tsx
@@ -26,6 +26,128 @@ interface DaemonStatus {
   sessionCount: number;
 }
 
+interface LocalServiceStatus {
+  installed: boolean;
+  running: boolean;
+  pid?: number;
+}
+
+function LocalServiceSection({ uiColors, labelStyle }: {
+  uiColors: Record<string, string>;
+  labelStyle: React.CSSProperties;
+}): React.ReactElement | null {
+  const isLinux = window.switchboard.platform === 'linux';
+  const [status, setStatus] = useState<LocalServiceStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  const refresh = useCallback(async () => {
+    try {
+      const s = await window.switchboard.daemon.localService.status();
+      setStatus(s);
+    } catch {
+      setStatus(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isLinux) return;
+    refresh();
+  }, [refresh, isLinux]);
+
+  if (!isLinux) return null;
+
+  const run = async (op: () => Promise<LocalServiceStatus>, confirmMsg?: string) => {
+    if (confirmMsg && !window.confirm(confirmMsg)) return;
+    setBusy(true);
+    setError('');
+    try {
+      const s = await op();
+      setStatus(s);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const btn: React.CSSProperties = {
+    padding: '2px 10px', fontSize: 11, backgroundColor: 'transparent',
+    border: `1px solid ${uiColors.inputBorder}`, borderRadius: 3,
+    color: uiColors.appText, cursor: busy ? 'wait' : 'pointer', opacity: busy ? 0.6 : 1,
+  };
+
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <label style={labelStyle}>Localhost service</label>
+      <div style={{ fontSize: 12, color: uiColors.appTextMuted, marginBottom: 8 }}>
+        Install the localhost daemon as a systemd user service so sessions survive client restarts.
+      </div>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '6px 8px', backgroundColor: uiColors.inputBg, borderRadius: 4,
+      }}>
+        {status === null ? (
+          <span style={{ fontSize: 12, color: uiColors.appTextMuted }}>Checking…</span>
+        ) : !status.installed ? (
+          <>
+            <span style={{ flex: 1, fontSize: 13, color: uiColors.appText }}>Not installed</span>
+            <button
+              data-testid="local-service-install"
+              onClick={() => run(() => window.switchboard.daemon.localService.install(),
+                'Install Switchboard daemon as a systemd user service?\n\nThe daemon will auto-start on login and survive client restarts.')}
+              disabled={busy}
+              style={btn}
+            >Install</button>
+          </>
+        ) : status.running ? (
+          <>
+            <span style={{ flex: 1, fontSize: 13, color: uiColors.appText }}>
+              Running{status.pid ? ` (PID ${status.pid})` : ''}
+            </span>
+            <button
+              data-testid="local-service-restart"
+              onClick={() => run(() => window.switchboard.daemon.localService.restart())}
+              disabled={busy} style={btn}
+            >Restart</button>
+            <button
+              data-testid="local-service-stop"
+              onClick={() => run(() => window.switchboard.daemon.localService.stop())}
+              disabled={busy} style={btn}
+            >Stop</button>
+            <button
+              data-testid="local-service-uninstall"
+              onClick={() => run(() => window.switchboard.daemon.localService.uninstall(),
+                'Uninstall the systemd user service?\n\nThe daemon will no longer auto-start; the client will spawn it as a child process instead.')}
+              disabled={busy}
+              style={{ ...btn, color: uiColors.errorText, borderColor: uiColors.errorText }}
+            >Uninstall</button>
+          </>
+        ) : (
+          <>
+            <span style={{ flex: 1, fontSize: 13, color: uiColors.appText }}>Installed, stopped</span>
+            <button
+              data-testid="local-service-start"
+              onClick={() => run(() => window.switchboard.daemon.localService.start())}
+              disabled={busy} style={btn}
+            >Start</button>
+            <button
+              data-testid="local-service-uninstall"
+              onClick={() => run(() => window.switchboard.daemon.localService.uninstall(),
+                'Uninstall the systemd user service?')}
+              disabled={busy}
+              style={{ ...btn, color: uiColors.errorText, borderColor: uiColors.errorText }}
+            >Uninstall</button>
+          </>
+        )}
+      </div>
+      {error && (
+        <div style={{ color: uiColors.errorText, fontSize: 12, marginTop: 6 }}>{error}</div>
+      )}
+    </div>
+  );
+}
+
 function DaemonSection({ uiColors, inputStyle, labelStyle }: {
   uiColors: Record<string, string>;
   inputStyle: React.CSSProperties;
@@ -132,6 +254,8 @@ function DaemonSection({ uiColors, inputStyle, labelStyle }: {
       <div style={{ fontSize: 12, color: uiColors.appTextMuted, marginBottom: 12 }}>
         Connect to Switchboard daemons running on this machine or remote hosts.
       </div>
+
+      <LocalServiceSection uiColors={uiColors} labelStyle={labelStyle} />
 
       {statuses.length > 0 && (
         <div style={{ marginBottom: 16 }}>

--- a/tests/main/local-daemon.test.ts
+++ b/tests/main/local-daemon.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as crypto from 'crypto';
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, spawn: spawnMock };
+});
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false },
+}));
+
+const originalPlatform = process.platform;
+Object.defineProperty(process, 'platform', { value: 'linux' });
+
+import { LocalDaemon } from '../../src/main/local-daemon';
+import * as systemd from '../../src/main/systemd-installer';
+
+let tmpHome: string;
+let originalHome: string | undefined;
+let originalSwitchboardHome: string | undefined;
+
+function writeDaemonConfig(): { token: string; fingerprint: string; port: number } {
+  const sbDir = path.join(tmpHome, '.switchboard');
+  fs.mkdirSync(sbDir, { recursive: true });
+  const certPath = path.join(sbDir, 'cert.pem');
+  fs.writeFileSync(certPath, '-----BEGIN CERT-----\nstub\n-----END CERT-----\n');
+  const token = 'test-token-xyz';
+  const fingerprint = crypto.createHash('sha256').update(fs.readFileSync(certPath, 'utf-8')).digest('hex');
+  const cfg = {
+    port: 3717,
+    auth: { token },
+    tls: { cert: certPath, key: certPath },
+  };
+  fs.writeFileSync(path.join(sbDir, 'daemon.json'), JSON.stringify(cfg));
+  return { token, fingerprint, port: 3717 };
+}
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sb-localdaemon-'));
+  originalHome = process.env.HOME;
+  originalSwitchboardHome = process.env.SWITCHBOARD_HOME;
+  process.env.HOME = tmpHome;
+  process.env.SWITCHBOARD_HOME = path.join(tmpHome, '.switchboard');
+  spawnMock.mockReset();
+});
+
+afterEach(() => {
+  if (originalHome !== undefined) process.env.HOME = originalHome;
+  if (originalSwitchboardHome === undefined) delete process.env.SWITCHBOARD_HOME;
+  else process.env.SWITCHBOARD_HOME = originalSwitchboardHome;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  systemd.__setRunner(undefined);
+});
+
+afterAll(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform });
+});
+
+describe('LocalDaemon service-detection branch', () => {
+  it('skips child spawn when systemd service is installed and running', async () => {
+    // Install a fake unit file
+    const unitDir = path.join(tmpHome, '.config', 'systemd', 'user');
+    fs.mkdirSync(unitDir, { recursive: true });
+    fs.writeFileSync(path.join(unitDir, 'switchboard-daemon.service'), 'stub');
+    writeDaemonConfig();
+
+    // Service reports active
+    systemd.__setRunner(async (_cmd, args) => {
+      if (args.includes('is-active')) return { stdout: 'active\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+
+    const daemon = new LocalDaemon();
+    const config = await daemon.start();
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(daemon.isServiceManaged()).toBe(true);
+    expect(config.id).toBe('localhost');
+    expect(config.host).toBe('127.0.0.1');
+    expect(config.port).toBe(3717);
+    expect(config.token).toBe('test-token-xyz');
+  });
+
+  it('stop() does not signal child when service-managed', async () => {
+    const unitDir = path.join(tmpHome, '.config', 'systemd', 'user');
+    fs.mkdirSync(unitDir, { recursive: true });
+    fs.writeFileSync(path.join(unitDir, 'switchboard-daemon.service'), 'stub');
+    writeDaemonConfig();
+    systemd.__setRunner(async () => ({ stdout: 'active\n', stderr: '' }));
+
+    const daemon = new LocalDaemon();
+    await daemon.start();
+
+    daemon.stop();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/main/systemd-installer.test.ts
+++ b/tests/main/systemd-installer.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const originalPlatform = process.platform;
+Object.defineProperty(process, 'platform', { value: 'linux' });
+
+import * as systemd from '../../src/main/systemd-installer';
+
+interface ExecCall { cmd: string; args: string[] }
+let calls: ExecCall[] = [];
+let runner: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+
+function setRunner(fn: typeof runner): void {
+  runner = fn;
+  systemd.__setRunner((cmd, args) => {
+    calls.push({ cmd, args });
+    return fn(cmd, args);
+  });
+}
+
+function runnerOk(stdout = ''): typeof runner {
+  return async () => ({ stdout, stderr: '' });
+}
+
+function runnerFail(): typeof runner {
+  return async () => { throw new Error('exit 1'); };
+}
+
+let tmpHome: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sb-systemd-'));
+  originalHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  calls = [];
+  setRunner(runnerOk());
+});
+
+afterEach(() => {
+  if (originalHome !== undefined) process.env.HOME = originalHome;
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+  systemd.__setRunner(undefined);
+});
+
+afterAll(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform });
+});
+
+describe('systemd-installer.renderUnitFile', () => {
+  it('produces a minimal valid unit file', () => {
+    const text = systemd.renderUnitFile({
+      daemonScript: '/opt/sb/daemon.js',
+      execBinary: '/usr/bin/node',
+      electronAsNode: false,
+    });
+    expect(text).toContain('[Unit]');
+    expect(text).toContain('Description=Switchboard daemon');
+    expect(text).toContain('ExecStart=/usr/bin/node /opt/sb/daemon.js');
+    expect(text).toContain('Restart=on-failure');
+    expect(text).toContain('WantedBy=default.target');
+    expect(text).not.toContain('ELECTRON_RUN_AS_NODE');
+  });
+
+  it('includes ELECTRON_RUN_AS_NODE when electronAsNode is true', () => {
+    const text = systemd.renderUnitFile({
+      daemonScript: '/opt/sb/daemon.js',
+      execBinary: '/opt/sb/electron',
+      electronAsNode: true,
+    });
+    expect(text).toContain('Environment=ELECTRON_RUN_AS_NODE=1');
+  });
+
+  it('includes SWITCHBOARD_HOME when dataDir is provided', () => {
+    const text = systemd.renderUnitFile({
+      daemonScript: '/opt/sb/daemon.js',
+      execBinary: '/usr/bin/node',
+      electronAsNode: false,
+      dataDir: '/var/lib/switchboard',
+    });
+    expect(text).toContain('Environment=SWITCHBOARD_HOME=/var/lib/switchboard');
+  });
+});
+
+describe('systemd-installer.isInstalled / getStatus', () => {
+  it('isInstalled returns false when unit file is absent', () => {
+    expect(systemd.isInstalled()).toBe(false);
+  });
+
+  it('isInstalled returns true when unit file is present', () => {
+    const unitDir = path.join(tmpHome, '.config', 'systemd', 'user');
+    fs.mkdirSync(unitDir, { recursive: true });
+    fs.writeFileSync(path.join(unitDir, 'switchboard-daemon.service'), 'stub');
+    expect(systemd.isInstalled()).toBe(true);
+  });
+
+  it('getStatus returns installed=false when no unit file', async () => {
+    const status = await systemd.getStatus();
+    expect(status).toEqual({ installed: false, running: false });
+  });
+
+  it('getStatus returns running=true and pid when active', async () => {
+    const unitDir = path.join(tmpHome, '.config', 'systemd', 'user');
+    fs.mkdirSync(unitDir, { recursive: true });
+    fs.writeFileSync(path.join(unitDir, 'switchboard-daemon.service'), 'stub');
+    setRunner(async (_cmd, args) => {
+      if (args.includes('is-active')) return { stdout: 'active\n', stderr: '' };
+      if (args.includes('show')) return { stdout: '12345\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+
+    const status = await systemd.getStatus();
+    expect(status.installed).toBe(true);
+    expect(status.running).toBe(true);
+    expect(status.pid).toBe(12345);
+  });
+
+  it('getStatus returns running=false when is-active fails', async () => {
+    const unitDir = path.join(tmpHome, '.config', 'systemd', 'user');
+    fs.mkdirSync(unitDir, { recursive: true });
+    fs.writeFileSync(path.join(unitDir, 'switchboard-daemon.service'), 'stub');
+    setRunner(runnerFail());
+    const status = await systemd.getStatus();
+    expect(status.running).toBe(false);
+    expect(status.pid).toBeUndefined();
+  });
+});
+
+describe('systemd-installer.install', () => {
+  it('writes unit file and runs daemon-reload + enable --now', async () => {
+    const daemonScript = path.join(tmpHome, 'daemon.js');
+    fs.writeFileSync(daemonScript, '// stub');
+
+    await systemd.install({
+      daemonScript,
+      execBinary: '/usr/bin/node',
+      electronAsNode: false,
+    });
+
+    const unitPath = path.join(tmpHome, '.config', 'systemd', 'user', 'switchboard-daemon.service');
+    expect(fs.existsSync(unitPath)).toBe(true);
+    const content = fs.readFileSync(unitPath, 'utf-8');
+    expect(content).toContain(`ExecStart=/usr/bin/node ${daemonScript}`);
+
+    expect(calls.some((c) => c.args[0] === '--user' && c.args[1] === 'daemon-reload')).toBe(true);
+    expect(calls.some((c) => c.args.includes('enable') && c.args.includes('--now'))).toBe(true);
+  });
+
+  it('rejects relative paths', async () => {
+    await expect(systemd.install({
+      daemonScript: 'daemon.js',
+      execBinary: '/usr/bin/node',
+      electronAsNode: false,
+    })).rejects.toThrow(/absolute/);
+  });
+
+  it('rejects when daemonScript does not exist', async () => {
+    await expect(systemd.install({
+      daemonScript: '/nonexistent/path/daemon.js',
+      execBinary: '/usr/bin/node',
+      electronAsNode: false,
+    })).rejects.toThrow(/not found/);
+  });
+});
+
+describe('systemd-installer.uninstall', () => {
+  it('removes the unit file and runs disable --now + daemon-reload', async () => {
+    const unitDir = path.join(tmpHome, '.config', 'systemd', 'user');
+    fs.mkdirSync(unitDir, { recursive: true });
+    const unitPath = path.join(unitDir, 'switchboard-daemon.service');
+    fs.writeFileSync(unitPath, 'stub');
+
+    await systemd.uninstall();
+
+    expect(fs.existsSync(unitPath)).toBe(false);
+    expect(calls.some((c) => c.args.includes('disable') && c.args.includes('--now'))).toBe(true);
+    expect(calls.some((c) => c.args.includes('daemon-reload'))).toBe(true);
+  });
+
+  it('does not throw when service was never enabled', async () => {
+    const unitDir = path.join(tmpHome, '.config', 'systemd', 'user');
+    fs.mkdirSync(unitDir, { recursive: true });
+    fs.writeFileSync(path.join(unitDir, 'switchboard-daemon.service'), 'stub');
+    let n = 0;
+    setRunner(async () => {
+      n++;
+      if (n === 1) throw new Error('not enabled');
+      return { stdout: '', stderr: '' };
+    });
+    await expect(systemd.uninstall()).resolves.toBeUndefined();
+  });
+});
+
+describe('systemd-installer.start/stop/restart', () => {
+  it('start calls systemctl --user start', async () => {
+    await systemd.start();
+    expect(calls[0]).toEqual({ cmd: 'systemctl', args: ['--user', 'start', 'switchboard-daemon'] });
+  });
+
+  it('stop calls systemctl --user stop', async () => {
+    await systemd.stop();
+    expect(calls[0]).toEqual({ cmd: 'systemctl', args: ['--user', 'stop', 'switchboard-daemon'] });
+  });
+
+  it('restart calls systemctl --user restart', async () => {
+    await systemd.restart();
+    expect(calls[0]).toEqual({ cmd: 'systemctl', args: ['--user', 'restart', 'switchboard-daemon'] });
+  });
+});


### PR DESCRIPTION
## Summary
- Localhost daemon can now be installed as a `systemd --user` service from Preferences → Daemons → Localhost service.
- Once installed, closing the client does not kill the daemon; the client connects to the running service instead of spawning a child.
- New module `src/main/systemd-installer.ts` wraps `systemctl --user` with strict `execFile` arg arrays (no shell interpolation).
- Linux-only; the UI panel is hidden on other platforms and IPC handlers reject.
- Closes Part 2 of Issue #32.

## What's new
- `systemd-installer.ts`: install/uninstall/start/stop/restart/status + unit-file renderer.
- `local-daemon.ts`: detects an installed-and-running service and skips the child spawn; `stop()` no longer signals the service.
- IPC + preload: `window.switchboard.daemon.localService.{install,uninstall,start,stop,restart,status}`.
- PreferencesModal: state-aware Localhost service panel (Not installed / Running+pid / Installed-stopped) with confirmation dialogs for install/uninstall.
- 280 tests passing (+18 new: 16 in `systemd-installer.test.ts`, 2 in `local-daemon.test.ts`).

## Test plan
- [ ] Install service from Preferences; verify unit file at `~/.config/systemd/user/switchboard-daemon.service`.
- [ ] `systemctl --user status switchboard-daemon` shows it active.
- [ ] Close client; daemon stays up (`pgrep -af daemon.js` still finds it).
- [ ] Reopen client; localhost connects without a fresh child process.
- [ ] Restart from Preferences; PID changes; sessions reappear (combined with Sprint 17).
- [ ] Uninstall; unit file gone; client reverts to child-spawn behavior on next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)