### PR TITLE
docs(roadmap): add v6 Fleet milestone (remote daemon management)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -44,9 +44,24 @@ These features run on the daemon where the PTY output stream lives. The daemon h
 
 ---
 
+## v6 — Fleet (daemon management across hosts)
+
+Features for installing, updating, and monitoring daemons across multiple servers without manual SSH work. Depends on the v3 Daemon architecture; independent of v4 (Flow II) and v5 (Intelligence).
+
+| Issue | Feature | Description | Side |
+|-------|---------|-------------|------|
+| TBD | Remote daemon provisioning | Client installs and starts a daemon on a remote host over SSH, reads the 6-digit pairing code from the SSH channel, and completes the handshake automatically | Client + remote |
+| TBD | Remote daemon upgrade | Push a newer daemon version to a paired host and restart the service | Client + remote |
+| TBD | Fleet status view | Single pane showing daemon version, health, and session count across all paired hosts | Client |
+| TBD | Connection-details management | Securely store SSH host/user/key references so re-provisioning or re-pairing does not require re-entry | Client |
+
+---
+
 ## Notes
 
 - The original backlog items B-01 through B-09 have been mapped to GitHub Issues #2–#10 and reassigned to milestones based on the daemon architecture decision (DEC-000001).
 - Issues #21 and #22 (filed by collaborator LachrymaGhost) are solved structurally by the daemon milestone — no separate implementation needed.
 - v4 (Flow II) and v5 (Intelligence) both depend on v3 (Daemon) but are independent of each other and could be worked in parallel.
+- v6 (Fleet) also depends on v3 (Daemon) and is independent of v4 and v5; remote provisioning surfaced during the Flow II live-test session (2026-05-29) when the user noted the existing pairing flow assumes a pre-installed daemon.
+- Issue numbers for v6 entries are TBD — to be filed by the user (GitHub Issues governance permits Claude to read/close but not create issues).
 - Bug issues (#13, #14, #15, #16, #20) are assigned to LachrymaGhost and tracked separately.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,3 +91,18 @@
 - Plugin API exposing session lifecycle events from the daemon for third-party integrations.
 
 **Dependencies:** Daemon
+
+---
+
+### 6. Fleet
+**Status:** `planned`
+
+**Outcome:** Daemons across multiple hosts can be installed, paired, and managed from the Switchboard client without manual SSH work. Adding a new server is a few clicks instead of a multi-step setup.
+
+**Observable conditions:**
+- **Client-driven remote daemon provisioning:** the user provides SSH connection details for a target host; the client installs the daemon binary (or runs an install script), starts it (as a `systemd --user` service when available), retrieves the 6-digit pairing code over the SSH channel, and completes the pairing handshake automatically.
+- (Future) Remote daemon upgrade — push a newer daemon version to a paired host and restart the service.
+- (Future) Fleet status view — single pane showing daemon version, health, and session count across all paired hosts.
+- (Future) Connection-details management — securely store SSH host/user/key references so re-provisioning or re-pairing does not require re-entry.
+
+**Dependencies:** Daemon (v3). Independent of Flow II (v4) and Intelligence (v5).


### PR DESCRIPTION
Adds a new **v6 Fleet** milestone to ROADMAP.md and BACKLOG.md for daemon installation and management across hosts. Surfaced during the Sprint 19/20 live-test session — the existing pairing flow assumes the daemon is already installed and running on the target host, which is real friction when adding new servers.

## Summary
- v6 outcome: install/pair/manage daemons across hosts from the client, no manual SSH required.
- First observable: client-driven remote provisioning (install over SSH, read the 6-digit pairing code from the SSH channel, complete the handshake automatically).
- Future observables noted in the milestone: remote upgrade, fleet status view, connection-details management.
- Depends on v3 (Daemon). Independent of v4 (Flow II) and v5 (Intelligence).
- Issue numbers TBD — per GitHub Issues governance Claude doesn't create issues; user will file them and we can link later.

Docs-only. No sprint file yet (that's for when this is ready to schedule).

## Test plan
- [x] ROADMAP and BACKLOG render correctly; new v6 section parses as Markdown.
- [x] No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)