### PR TITLE
fix(fleet): five live-test fixes on top of Sprint 21 (0.5.0-rc.2 → rc.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0-rc.2",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {
@@ -17,7 +17,7 @@
     "test:watch": "vitest",
     "pack": "npm run build && electron-builder --dir",
     "dist": "npm run build && electron-builder",
-    "dist:appimage": "npm run build && electron-builder --linux AppImage",
+    "dist:appimage": "npm run build && npm run dist:daemon-tarball && electron-builder --linux AppImage",
     "dist:daemon-tarball": "npm run build:daemon && bash scripts/build-daemon-tarball.sh"
   },
   "author": "mrkelley <mrkelley@users.noreply.github.com>",
@@ -48,6 +48,9 @@
       "dist/**/*",
       "node_modules/**/*",
       "package.json"
+    ],
+    "extraResources": [
+      { "from": "release/switchboard-daemon.tar.gz", "to": "switchboard-daemon.tar.gz" }
     ],
     "extraMetadata": {
       "main": "dist/main/main/main.js"

--- a/scripts/build-daemon-tarball.sh
+++ b/scripts/build-daemon-tarball.sh
@@ -93,5 +93,10 @@ EOF
 mkdir -p "$OUT_DIR"
 tar -czf "$OUT_DIR/$OUT_FILE" -C "$STAGE" switchboard-daemon
 
+# Also emit a versionless copy so electron-builder's extraResources can grab a
+# stable filename regardless of the current version bump. The versioned file
+# is kept for release-asset uploads and manual install docs.
+cp "$OUT_DIR/$OUT_FILE" "$OUT_DIR/switchboard-daemon.tar.gz"
+
 SIZE=$(du -h "$OUT_DIR/$OUT_FILE" | cut -f1)
-echo "wrote $OUT_DIR/$OUT_FILE ($SIZE)"
+echo "wrote $OUT_DIR/$OUT_FILE ($SIZE) and switchboard-daemon.tar.gz"

--- a/src/main/remote-provisioner.ts
+++ b/src/main/remote-provisioner.ts
@@ -377,15 +377,28 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Resolve the packaged daemon-tarball path. In dev, the tarball lives under
- * release/ next to the app root; when running from a packaged AppImage, we
- * expect it to be pre-built and packaged next to the app resources.
+ * Resolve the packaged daemon-tarball path. Packaged AppImages carry the
+ * tarball under a stable name in process.resourcesPath (see the
+ * `build.extraResources` entry in package.json). In dev, we fall back to
+ * versioned/stable copies in release/.
  */
 export function defaultTarballPath(version: string): string {
-  const filename = `switchboard-daemon-${version}-linux-x64.tar.gz`;
-  const packaged = path.join(process.resourcesPath || '', filename);
-  if (fs.existsSync(packaged)) return packaged;
-  const dev = path.join(app.getAppPath(), '..', '..', 'release', filename);
-  if (fs.existsSync(dev)) return dev;
-  return path.join(process.cwd(), 'release', filename);
+  const versioned = `switchboard-daemon-${version}-linux-x64.tar.gz`;
+  const stable = 'switchboard-daemon.tar.gz';
+
+  // Packaged: extraResources copies release/switchboard-daemon.tar.gz here.
+  const packagedStable = path.join(process.resourcesPath || '', stable);
+  if (fs.existsSync(packagedStable)) return packagedStable;
+
+  // Dev: repo-relative release directory.
+  for (const name of [stable, versioned]) {
+    const dev = path.join(app.getAppPath(), '..', '..', 'release', name);
+    if (fs.existsSync(dev)) return dev;
+    const cwd = path.join(process.cwd(), 'release', name);
+    if (fs.existsSync(cwd)) return cwd;
+  }
+
+  // Last-ditch: return the packaged path so the error message points at the
+  // right place ("expected the AppImage to bundle the tarball at ...").
+  return packagedStable;
 }

--- a/src/renderer/components/RemoteProvisioningModal.tsx
+++ b/src/renderer/components/RemoteProvisioningModal.tsx
@@ -191,6 +191,23 @@ export default function RemoteProvisioningModal({ isOpen, onClose }: Props): Rea
 
         {phase !== 'form' && (
           <>
+            {steps.length === 0 && phase === 'running' && (
+              <div style={{ color: uiColors.appTextMuted, fontSize: 13, marginBottom: 12 }}>
+                Starting…
+              </div>
+            )}
+            {error && (
+              <div
+                data-testid="modal-error"
+                style={{
+                  padding: '8px 10px', marginBottom: 12,
+                  backgroundColor: uiColors.inputBg, borderRadius: 4,
+                  color: uiColors.errorText, fontSize: 12, wordBreak: 'break-word',
+                }}
+              >
+                {error}
+              </div>
+            )}
             <div style={{ marginBottom: 18 }}>
               {steps.map((s) => (
                 <div key={s.id} data-testid={`step-${s.id}`} style={{
@@ -238,12 +255,18 @@ export default function RemoteProvisioningModal({ isOpen, onClose }: Props): Rea
 
             {phase === 'failed' && (
               <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
-                {failedStep && (
+                {failedStep ? (
                   <button
                     data-testid="retry-button"
                     onClick={() => void startProvision(failedStep.id)}
                     style={primaryBtn}
                   >Retry from “{failedStep.label}”</button>
+                ) : (
+                  <button
+                    data-testid="restart-button"
+                    onClick={() => void startProvision()}
+                    style={primaryBtn}
+                  >Retry from start</button>
                 )}
                 <button onClick={onClose} style={btn}>Close</button>
               </div>


### PR DESCRIPTION
Iterative fixes discovered by live-testing PR #49's remote provisioning against a real Ubuntu VM. Five separate bugs, each shipped as its own commit + rc so the history stays useful for anyone doing archaeology later.

## rc.2 — bundle the daemon tarball into the AppImage
\`dist:daemon-tarball\` wrote the artifact into \`release/\` but nothing was copying it into the AppImage. \`defaultTarballPath()\` couldn't find it inside the packaged app → provisioner failed at step 4 (upload-tarball) before any progress broadcast reached the UI.
- \`scripts/build-daemon-tarball.sh\` also emits a stable-name copy at \`release/switchboard-daemon.tar.gz\`.
- \`package.json\` \`extraResources\` places it at \`resources/switchboard-daemon.tar.gz\` in the AppImage.
- \`defaultTarballPath\` prefers the stable name in \`process.resourcesPath\`.
- \`RemoteProvisioningModal\` renders the \`error\` state variable in ALL non-form phases (not just \`form\`), and shows a \"Retry from start\" fallback when the failure has no failedStep to retry from. Before this, an early throw left the modal showing only a bare Close button.

## rc.3 — remote daemons must bind to 0.0.0.0
Daemon defaults to \`127.0.0.1\`, correct for the client-spawned local daemon (never expose it) but wrong for a remote-provisioned one. \`ECONNREFUSED\` at the pair step.
- \`src/daemon/config.ts\`: \`SWITCHBOARD_HOST\` env var overrides both saved config and defaults; runtime override that always wins. \`SWITCHBOARD_PORT\` for symmetry.
- \`src/main/remote-provisioner.ts\` systemd unit: \`Environment=SWITCHBOARD_HOST=0.0.0.0\`.

## rc.4 — install-service must restart, not enable --now
\`systemctl --user enable --now\` is a no-op when the service is already running. Reprovisioning wrote the new unit file with the new env but left the old process (still bound to 127.0.0.1) alive.
- install-service now does \`daemon-reload && enable && restart\`.
- extract does \`systemctl stop || true\` first so we don't overwrite a live daemon's node-pty \`.node\` file.

## rc.5 — bad cwd was crashing the daemon silently
Passing a cwd that doesn't exist on the target crashed the daemon with no log line — node-pty behavior we can't fully explain. Also, the client just \`console.warn\`'d daemon errors, so the user had zero visibility.
- \`daemon.ts handleSpawn\`: \`fs.statSync(cwd)\` before spawn; return a clean \`SPAWN_FAILED\` error if it's missing or not a directory.
- \`daemon.ts\` entry: \`process.on('uncaughtException')\` / \`unhandledRejection\` safety-net handlers so future edge cases log a stack instead of dying.
- \`connection-manager.ts\`: broadcasts \`daemon:error\` to renderer.
- \`preload.ts\`: exposes \`daemon.onError\`.
- \`App.tsx\`: subscribed and displayed via \`window.alert()\`.

## rc.6 — window.alert() wedges a sandboxed renderer
The rc.5 alert() blocked the sandboxed contextIsolated renderer thread. When IPC arrived during the modal (daemon status pings, session events), the whole app wedged — required Quit + relaunch.
- Replaced with a dismissible in-app banner rendered at the top of the main content area. No native modal, no thread blocking.

## Test plan
- [x] \`npm run test\` — **352/352 pass** on every commit in this branch.
- [x] \`npm run dist:appimage\` produces \`Switchboard-0.5.0-rc.6.AppImage\` (108M); \`unsquashfs\` confirms the daemon tarball is bundled at \`resources/switchboard-daemon.tar.gz\`.
- [x] Live E2E on Ubuntu 24.04: Add remote daemon → paired in ~60s; daemon appears in Preferences → Daemons as \"connected\".
- [x] Spawn a session with a valid cwd on the remote daemon: works, input echoes, output streams.
- [x] Spawn with an invalid cwd: daemon returns \`SPAWN_FAILED\`, red banner shows the error, app stays fully responsive.

## Known follow-ups (not in this PR)
- Empty daemon groups don't appear in the sidebar until they have at least one session. Confusing after a fresh pair. Small fix in \`Sidebar.tsx\` \`computeGroups\`.
- Node-pty prebuilt binary in the daemon tarball is Node-20 ABI. Node 22 targets need a separate prebuild variant.
- Persisted SSH connection details for re-provisioning without re-entry (was already deferred in the Sprint 21 plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrqJNfkeYjbet6eQs71vCK