### PR TITLE
fix(fleet): four more live-test fixes (0.5.0-rc.3 → rc.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.5.0-rc.2",
+  "version": "0.5.0-rc.3",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.5.0-rc.3",
+  "version": "0.5.0-rc.4",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.5.0-rc.5",
+  "version": "0.5.0-rc.6",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.5.0-rc.4",
+  "version": "0.5.0-rc.5",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -68,6 +68,21 @@ export function getCertFingerprint(certPath: string): string {
   return hash;
 }
 
+/**
+ * Runtime overrides that always win over both saved config and defaults.
+ * `SWITCHBOARD_HOST` lets remote-provisioned daemons bind to 0.0.0.0 without
+ * a config-file edit — the systemd unit our client writes sets it explicitly.
+ */
+function envOverrides(): Partial<DaemonConfig> {
+  const out: Partial<DaemonConfig> = {};
+  if (process.env.SWITCHBOARD_HOST) out.host = process.env.SWITCHBOARD_HOST;
+  if (process.env.SWITCHBOARD_PORT) {
+    const p = parseInt(process.env.SWITCHBOARD_PORT, 10);
+    if (Number.isFinite(p)) out.port = p;
+  }
+  return out;
+}
+
 export function loadConfig(configPath?: string): DaemonConfig {
   const dataDir = getDataDir();
   const cfgPath = configPath || path.join(dataDir, 'daemon.json');
@@ -79,11 +94,12 @@ export function loadConfig(configPath?: string): DaemonConfig {
       ...DEFAULTS,
       sessionPersistPath: path.join(dataDir, 'sessions.json'),
       ...parsed,
+      ...envOverrides(),
     };
   }
 
   // First-run setup
-  return initConfig(dataDir, cfgPath);
+  return { ...initConfig(dataDir, cfgPath), ...envOverrides() };
 }
 
 export function initConfig(dataDir: string, cfgPath: string): DaemonConfig {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1,4 +1,5 @@
 import * as os from 'os';
+import * as fs from 'fs';
 import { randomUUID } from 'crypto';
 import { loadConfig, getCertFingerprint } from './config';
 import { PtyManager } from './pty-manager';
@@ -253,6 +254,28 @@ export class Daemon {
   }
 
   private handleSpawn(conn: ClientConnection, name: string, cwd: string, command?: string): void {
+    // Fail loudly and cleanly when cwd doesn't exist on the target — node-pty's
+    // behavior in that case has historically been to emit an unhandled event
+    // that takes the daemon down. Validate first so we return a clear error.
+    try {
+      const st = fs.statSync(cwd);
+      if (!st.isDirectory()) {
+        this.transport.send(conn.id, {
+          type: 'error',
+          code: 'SPAWN_FAILED',
+          message: `cwd is not a directory: ${cwd}`,
+        });
+        return;
+      }
+    } catch (err) {
+      this.transport.send(conn.id, {
+        type: 'error',
+        code: 'SPAWN_FAILED',
+        message: `cwd does not exist on this host: ${cwd}`,
+      });
+      return;
+    }
+
     try {
       const session = this.ptyManager.spawn({ name, cwd, command });
       this.idleDetector.addSession(session.id);
@@ -407,6 +430,16 @@ export class Daemon {
 // --- CLI Entry Point ---
 
 if (require.main === module) {
+  // Safety net: log unhandled errors instead of silently exiting. node-pty
+  // in particular can emit unexpected events for edge-case spawns; without
+  // these handlers the daemon dies without leaving a trace.
+  process.on('uncaughtException', (err) => {
+    console.error('uncaughtException:', err instanceof Error ? err.stack : err);
+  });
+  process.on('unhandledRejection', (reason) => {
+    console.error('unhandledRejection:', reason instanceof Error ? reason.stack : reason);
+  });
+
   const daemon = new Daemon();
 
   process.on('SIGTERM', async () => {

--- a/src/main/connection-manager.ts
+++ b/src/main/connection-manager.ts
@@ -670,6 +670,12 @@ export class ConnectionManager {
 
       case 'error':
         console.warn(`Daemon ${conn.config.name} error: [${msg.code}] ${msg.message}`);
+        broadcast('daemon:error', {
+          daemonId: conn.config.id,
+          daemonName: conn.config.name,
+          code: (msg as { code?: string }).code ?? 'ERROR',
+          message: (msg as { message?: string }).message ?? '',
+        });
         break;
     }
   }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -129,6 +129,13 @@ const api = {
       ipcRenderer.on('daemon:connected', handler);
       return () => ipcRenderer.removeListener('daemon:connected', handler);
     },
+    onError(callback: (err: { daemonId: string; daemonName: string; code: string; message: string }) => void): () => void {
+      const handler = (_event: Electron.IpcRendererEvent, err: { daemonId: string; daemonName: string; code: string; message: string }) => {
+        callback(err);
+      };
+      ipcRenderer.on('daemon:error', handler);
+      return () => ipcRenderer.removeListener('daemon:error', handler);
+    },
     pair(host: string, port: number, clientName: string) {
       return ipcRenderer.invoke('daemon:pair', { host, port, clientName });
     },

--- a/src/main/remote-provisioner.ts
+++ b/src/main/remote-provisioner.ts
@@ -249,8 +249,13 @@ export class RemoteProvisioner {
   }
 
   private async extract(): Promise<void> {
+    // Stop any running instance first so we don't overwrite files under a live
+    // process (node's require cache aside, node-pty's .node file being rewritten
+    // while loaded is asking for trouble). `|| true` because the service may
+    // not yet exist on a first install.
     await ssh.run(
       this.req.target,
+      'systemctl --user stop switchboard-daemon 2>/dev/null || true; ' +
       `mkdir -p ${REMOTE_INSTALL_ROOT} && rm -rf ${REMOTE_INSTALL_ROOT}/switchboard-daemon && ` +
       `tar -xzf ${REMOTE_TARBALL_TMP} -C ${REMOTE_INSTALL_ROOT} && rm -f ${REMOTE_TARBALL_TMP}`,
       { timeoutMs: 30_000 },
@@ -261,16 +266,20 @@ export class RemoteProvisioner {
   private async installService(): Promise<void> {
     if (!this.probed) throw new Error('installService called before probe-target populated remoteHome/nodePath');
     const unit = buildUnitFile(this.probed.remoteHome, this.probed.nodePath);
-    // Write the unit file via `cat` heredoc, then reload + enable --now.
+    // Write the unit file, reload, ensure enabled for auto-start, then
+    // *restart* — not `enable --now`, which is a no-op when the service is
+    // already running and would leave the old process (with old env vars)
+    // in place after a reprovision.
     const marker = 'SB_UNIT_END';
     const script =
       'mkdir -p ~/.config/systemd/user && ' +
       `FILE=${REMOTE_UNIT_PATH} && ` +
       safeHeredoc(marker, unit) +
       'systemctl --user daemon-reload && ' +
-      'systemctl --user enable --now switchboard-daemon';
+      'systemctl --user enable switchboard-daemon && ' +
+      'systemctl --user restart switchboard-daemon';
     await ssh.run(this.req.target, script, { timeoutMs: 30_000 });
-    this.setStep('install-service', { message: 'service enabled and started' });
+    this.setStep('install-service', { message: 'service enabled and restarted' });
   }
 
   private async waitReady(): Promise<void> {

--- a/src/main/remote-provisioner.ts
+++ b/src/main/remote-provisioner.ts
@@ -77,6 +77,10 @@ function buildUnitFile(remoteHome: string, nodePath: string): string {
     '',
     '[Service]',
     'Type=simple',
+    // Bind on all interfaces so the client (on another host) can reach us.
+    // TLS + fingerprint pinning + token auth still gate access; the local-only
+    // daemon spawned by the client still defaults to 127.0.0.1.
+    'Environment=SWITCHBOARD_HOST=0.0.0.0',
     `ExecStart=${nodePath} ${daemonJs}`,
     'Restart=on-failure',
     'RestartSec=5',

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,6 +18,7 @@ function AppContent(): React.ReactElement {
   const [sidebarVisible, setSidebarVisible] = useState(true);
   const [searchVisible, setSearchVisible] = useState(false);
   const [queueBarSessionId, setQueueBarSessionId] = useState<string | null>(null);
+  const [errorBanner, setErrorBanner] = useState<string | null>(null);
 
   const activeSession = state.sessions.find((s) => s.id === state.activeSessionId) || null;
 
@@ -82,11 +83,12 @@ function AppContent(): React.ReactElement {
   // Listen for daemon-created sessions (async spawn via daemon).
   // Also hydrate from main's current session list to recover from any
   // session-created broadcasts that fired before this listener attached.
-  // Surface daemon-side errors (e.g., SPAWN_FAILED for a bad cwd) instead of
-  // dropping them into the main-process console where the user never sees them.
+  // Surface daemon-side errors (e.g., SPAWN_FAILED for a bad cwd) in a
+  // dismissible in-app banner. Native window.alert() from a sandboxed
+  // renderer can wedge the app if IPC arrives during the modal.
   useEffect(() => {
     const unsub = (window as any).switchboard.daemon.onError?.((err: { daemonName: string; code: string; message: string }) => {
-      window.alert(`Daemon “${err.daemonName}” error [${err.code}]: ${err.message}`);
+      setErrorBanner(`${err.daemonName}: [${err.code}] ${err.message}`);
     });
     return unsub;
   }, []);
@@ -193,6 +195,30 @@ function AppContent(): React.ReactElement {
     >
       {sidebarVisible && <Sidebar />}
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {errorBanner && (
+          <div
+            data-testid="daemon-error-banner"
+            style={{
+              padding: '8px 12px',
+              backgroundColor: uiColors.errorText,
+              color: '#fff',
+              fontSize: 12,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 12,
+            }}
+          >
+            <span style={{ flex: 1, wordBreak: 'break-word' }}>{errorBanner}</span>
+            <button
+              onClick={() => setErrorBanner(null)}
+              style={{
+                background: 'transparent', border: '1px solid #fff', color: '#fff',
+                padding: '2px 8px', borderRadius: 3, fontSize: 11, cursor: 'pointer',
+              }}
+            >Dismiss</button>
+          </div>
+        )}
         <Header
           activeSessionName={activeSession?.name || null}
           onNewSession={() => setModalOpen(true)}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -82,6 +82,15 @@ function AppContent(): React.ReactElement {
   // Listen for daemon-created sessions (async spawn via daemon).
   // Also hydrate from main's current session list to recover from any
   // session-created broadcasts that fired before this listener attached.
+  // Surface daemon-side errors (e.g., SPAWN_FAILED for a bad cwd) instead of
+  // dropping them into the main-process console where the user never sees them.
+  useEffect(() => {
+    const unsub = (window as any).switchboard.daemon.onError?.((err: { daemonName: string; code: string; message: string }) => {
+      window.alert(`Daemon “${err.daemonName}” error [${err.code}]: ${err.message}`);
+    });
+    return unsub;
+  }, []);
+
   useEffect(() => {
     const knownIds = new Set<string>();
     const unsub = window.switchboard.session.onSessionCreated((session: import('../shared/types').SessionInfo) => {


### PR DESCRIPTION
Follow-up to PR #50 (rc.2 tarball-bundling). PR #50 was merged with only the rc.2 commit; the four subsequent fixes never got their own PR because pushes to a closed branch don't reopen it. Bundling them here.

Each rc is a discrete commit for future archaeology.

## rc.3 — remote daemons must bind to 0.0.0.0
Daemon defaults to \`127.0.0.1\`, correct for the client-spawned local daemon (never expose it) but wrong for a remote-provisioned one → \`ECONNREFUSED\` at the pair step.
- \`src/daemon/config.ts\`: \`SWITCHBOARD_HOST\` env var overrides both saved config and defaults; runtime override that always wins. \`SWITCHBOARD_PORT\` for symmetry.
- \`src/main/remote-provisioner.ts\` systemd unit: \`Environment=SWITCHBOARD_HOST=0.0.0.0\`.

## rc.4 — install-service must restart, not enable --now
\`systemctl --user enable --now\` is a no-op when the service is already running. Reprovisioning wrote the new unit file with the new env but left the old process (still bound to 127.0.0.1) alive.
- install-service now does \`daemon-reload && enable && restart\`.
- extract does \`systemctl stop || true\` first so we don't overwrite a live daemon's node-pty \`.node\` file.

## rc.5 — bad cwd was crashing the daemon silently
Passing a cwd that doesn't exist on the target crashed the daemon with no log line. Also, the client just \`console.warn\`'d daemon errors, so the user had zero visibility.
- \`daemon.ts handleSpawn\`: \`fs.statSync(cwd)\` before spawn; return a clean \`SPAWN_FAILED\` error if it's missing or not a directory.
- \`daemon.ts\` entry: \`process.on('uncaughtException')\` / \`unhandledRejection\` safety-net handlers.
- \`connection-manager.ts\`: broadcasts \`daemon:error\` to renderer.
- \`preload.ts\`: exposes \`daemon.onError\`.
- \`App.tsx\`: subscribed and displayed via \`window.alert()\`.

## rc.6 — window.alert() wedges a sandboxed renderer
rc.5's alert() blocked the sandboxed contextIsolated renderer thread. When IPC arrived during the modal (daemon status pings, session events), the whole app wedged — Quit + relaunch required.
- Replaced with a dismissible in-app banner at the top of the main content area. Non-blocking, no native modal.

## Test plan
- [x] \`npm run test\` — 352/352 pass.
- [x] \`npm run dist:appimage\` produces \`Switchboard-0.5.0-rc.6.AppImage\` (108M).
- [x] Live E2E on Ubuntu 24.04: Add remote daemon → paired in ~60s; daemon connects and stays connected.
- [x] Spawn on remote with valid cwd: works, input echoes, output streams.
- [x] Spawn on remote with invalid cwd: red banner shows \`SPAWN_FAILED\`, app stays fully responsive.

## Known follow-ups (not in this PR)
- Empty daemon groups don't appear in the sidebar until they have a session. Small fix in \`Sidebar.tsx computeGroups\`.
- Bundled node-pty is Node-20 ABI; Node 22 targets need a separate prebuild variant.
- Persisted SSH connection-details for re-provisioning without re-entry (already in the Sprint 21 non-goals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrqJNfkeYjbet6eQs71vCK