### PR TITLE
fix(daemon): login shell + client diag (0.5.0-rc.10 → rc.11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.5.0-rc.9",
+  "version": "0.5.0-rc.10",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.5.0-rc.10",
+  "version": "0.5.0-rc.11",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -16,6 +16,7 @@ export class Daemon {
   private ptyManager: PtyManager;
   private idleDetector: IdleDetector;
   private buffers = new Map<string, OutputBuffer>();
+  private spawnTimes = new Map<string, number>();
   private sessionStore: SessionStore;
   private queuedPrompts: QueuedPrompts;
   private transport: TransportServer;
@@ -74,6 +75,27 @@ export class Daemon {
     });
 
     this.ptyManager.setOnExit((sessionId, exitCode) => {
+      const spawnedAt = this.spawnTimes.get(sessionId);
+      const durationMs = spawnedAt !== undefined ? Date.now() - spawnedAt : -1;
+      this.spawnTimes.delete(sessionId);
+      console.log(`[session:exit] id=${sessionId} code=${exitCode} durationMs=${durationMs}`);
+
+      // Fast-fail: if the session exited within 2s with a non-zero code, the
+      // spawned command almost certainly failed to launch (bad PATH, syntax
+      // error, missing binary). Surface it as an error so the client shows
+      // it in the banner, since the pane vanishes too fast to read.
+      if (exitCode !== 0 && durationMs >= 0 && durationMs < 2000) {
+        const buf = this.buffers.get(sessionId);
+        const tail = buf ? buf.getAll().slice(-2000) : '';
+        this.transport.broadcast({
+          type: 'error',
+          code: 'SESSION_EXITED_QUICKLY',
+          message: tail
+            ? `Session exited in ${durationMs}ms with code ${exitCode}: ${tail.trim()}`
+            : `Session exited in ${durationMs}ms with code ${exitCode} (no output captured).`,
+        });
+      }
+
       this.idleDetector.removeSession(sessionId);
       this.queuedPrompts.removeSession(sessionId);
       this.transport.broadcast({
@@ -276,8 +298,10 @@ export class Daemon {
       return;
     }
 
+    console.log(`[session:spawn] name=${JSON.stringify(name)} cwd=${cwd} command=${command ? JSON.stringify(command) : '(default shell)'}`);
     try {
       const session = this.ptyManager.spawn({ name, cwd, command });
+      this.spawnTimes.set(session.id, Date.now());
       this.idleDetector.addSession(session.id);
 
       // Create output buffer

--- a/src/daemon/pty-manager.ts
+++ b/src/daemon/pty-manager.ts
@@ -36,16 +36,18 @@ export class PtyManager {
   spawn(config: SessionConfig): SessionInfo {
     const id = config.id ?? randomUUID();
 
-    // If a command is provided, run it via the user's shell (`$SHELL -c "cmd"`)
-    // so multi-word commands like `claude -c` parse into argv correctly.
-    // Without wrapping, node-pty passes the whole string as argv[0] and execvp
-    // fails with ENOENT ("no file named 'claude -c'"). Empty command → spawn
-    // the shell interactively.
+    // If a command is provided, run it via the user's shell as a LOGIN shell
+    // (`$SHELL -l -c "cmd"`) so multi-word commands parse into argv AND the
+    // user's login PATH is populated. The daemon inherits systemd-user's lean
+    // PATH (no ~/.local/bin, no nvm, no cargo); ~/.bashrc's PATH edits are
+    // skipped by its non-interactive early-return; so only a login shell
+    // sources ~/.profile and picks up things like `claude` at ~/.local/bin.
+    // Empty command → spawn the shell interactively (which sources rc files).
     let execPath: string;
     let execArgs: string[];
     if (config.command) {
       execPath = process.env.SHELL || this.getDefaultShell();
-      execArgs = ['-c', config.command];
+      execArgs = ['-l', '-c', config.command];
     } else {
       execPath = this.getDefaultShell();
       execArgs = [];

--- a/src/main/connection-manager.ts
+++ b/src/main/connection-manager.ts
@@ -169,8 +169,9 @@ export class ConnectionManager {
       }
     });
 
-    ws.on('error', () => {
-      // Error is followed by close event
+    ws.on('error', (err) => {
+      console.error(`[conn] ${conn.config.name} WS error:`, err.message);
+      // Close event follows and handles state transition.
     });
   }
 
@@ -321,7 +322,20 @@ export class ConnectionManager {
    */
   spawn(daemonId: string, name: string, cwd: string, command?: string): void {
     const conn = this.connections.get(daemonId);
-    if (!conn || conn.status !== 'connected') throw new Error('Daemon not connected');
+    if (!conn) {
+      const known = Array.from(this.connections.keys());
+      console.error(`[spawn] no connection for daemonId=${JSON.stringify(daemonId)}. Known: ${JSON.stringify(known)}`);
+      throw new Error(`Daemon not connected: unknown daemonId ${daemonId} (known: ${known.join(', ') || 'none'})`);
+    }
+    if (conn.status !== 'connected') {
+      console.error(`[spawn] daemon ${conn.config.name} status=${conn.status} wsReadyState=${conn.ws?.readyState}`);
+      throw new Error(`Daemon not connected: ${conn.config.name} is ${conn.status}`);
+    }
+    if (!conn.ws || conn.ws.readyState !== 1 /* OPEN */) {
+      console.error(`[spawn] daemon ${conn.config.name} status='connected' but ws is ${conn.ws?.readyState}`);
+      throw new Error(`Daemon not connected: ${conn.config.name} socket dropped`);
+    }
+    console.log(`[spawn] → ${conn.config.name}: name=${JSON.stringify(name)} cwd=${cwd} command=${command ? JSON.stringify(command) : '(default shell)'}`);
     this.sendToDaemon(conn, { type: 'session:spawn', name, cwd, command });
   }
 
@@ -699,6 +713,9 @@ export class ConnectionManager {
   }
 
   private setStatus(conn: ManagedConnection, status: ConnectionStatus): void {
+    if (conn.status !== status) {
+      console.log(`[conn] ${conn.config.name} (${conn.config.id}): ${conn.status} → ${status}`);
+    }
     conn.status = status;
     broadcast('daemon:status-changed', {
       daemonId: conn.config.id,

--- a/tests/daemon/pty-manager.test.ts
+++ b/tests/daemon/pty-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockPty } = vi.hoisted(() => {
+const { mockPty, spawnSpy } = vi.hoisted(() => {
   const mockPty = {
     pid: 42,
     write: vi.fn(),
@@ -9,11 +9,12 @@ const { mockPty } = vi.hoisted(() => {
     onData: vi.fn(),
     onExit: vi.fn(),
   };
-  return { mockPty };
+  const spawnSpy = vi.fn().mockReturnValue(mockPty);
+  return { mockPty, spawnSpy };
 });
 
 vi.mock('node-pty', () => ({
-  spawn: vi.fn().mockReturnValue(mockPty),
+  spawn: spawnSpy,
 }));
 
 import { PtyManager } from '../../src/daemon/pty-manager';
@@ -119,5 +120,18 @@ describe('PtyManager', () => {
     manager.spawn({ name: 'b', cwd: '/tmp' });
     manager.closeAll();
     expect(manager.getAll()).toHaveLength(0);
+  });
+
+  it('runs a command via login shell so PATH picks up user bin dirs', () => {
+    manager.spawn({ name: 'x', cwd: '/tmp', command: 'claude -c' });
+    expect(spawnSpy).toHaveBeenCalled();
+    const [, args] = spawnSpy.mock.calls[0];
+    expect(args).toEqual(['-l', '-c', 'claude -c']);
+  });
+
+  it('spawns an interactive shell (no -c) when command is empty', () => {
+    manager.spawn({ name: 'x', cwd: '/tmp' });
+    const [, args] = spawnSpy.mock.calls[0];
+    expect(args).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Two RCs bundled — a real bug fix (rc.10) and diagnostic hardening (rc.11) that came out of debugging it.

### rc.10 — login shell for command-mode spawns

Sessions with any user-provided command died silently on spawn (exit 127, invisible).

- `bash -c 'cmd'` runs a **non-interactive** shell — doesn't source `.profile`
- Ubuntu's `~/.bashrc` returns early for non-interactive shells
- Daemon inherits systemd-user's lean PATH: no `~/.local/bin`, no nvm, no cargo
- Result: `claude`, `claude -c`, and any tool in a user-only PATH dir → `command not found` → exit 127 → pane vanishes before you can read it

**Fix:** `$SHELL -l -c 'cmd'` — login shell sources `.profile`, PATH matches what a real terminal sees. Also added spawn/exit logging in the daemon and a `SESSION_EXITED_QUICKLY` broadcast for fast-fail sessions (surfaces via the existing daemon:error → red banner path in the client).

### rc.11 — client-side diagnostics

Chased a "Daemon not connected" report where the daemons popup said `connected`, TCP was ESTAB, but pty:spawn threw generically. No supporting output existed to tell us which state check was failing.

- `spawn()` now distinguishes "unknown daemonId" / "wrong status" / "ws dropped" and names the daemon + known-daemon list in the error
- `setStatus()` logs every state transition
- Managed-connection WS `error` handler no longer swallowed — logs to stderr (silent WS errors were the whole reason auth-fails were invisible)

Verified working end-to-end after rebuild + reprovision: user is talking to Claude via `claude -c --dangerously-skip-permissions` through the fixed client.

## Test plan

- [x] Unit tests pass (356/356)
- [x] Type-check clean
- [x] AppImage builds (142 MB, both rcs)
- [x] Manual: session with `command=claude -c --dangerously-skip-permissions` starts and stays up (was: died silently)
- [x] Manual: `[session:spawn]` and `[session:exit]` lines appear in daemon journal
- [ ] Broader testing across multiple remotes (operator will run after merge)

## Follow-ups (not blocking, tracked separately)

- Client bug: stopping the last session on a daemon hides it from the sidebar until a session exists again
- Formal lab-CA mTLS + Bosun inject API — separate sprint, plan in `switchboard-daemon-input.plan.md` (untracked, not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrqJNfkeYjbet6eQs71vCK