### PR TITLE
chore(ci): skip electron-winstaller postinstall in arm containers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,23 +41,37 @@ jobs:
         if: matrix.docker_platform != ''
         uses: docker/setup-qemu-action@v3
 
+      # Install + TS build happen on the host — arch-agnostic and much faster
+      # than doing them under QEMU emulation. --ignore-scripts sidesteps
+      # electron-winstaller's postinstall (Windows-only helper transitively
+      # pulled in by electron-builder — it copies an arch-specific 7-Zip binary
+      # and has no armv7l variant, so it crashes inside the arm containers).
+      # We don't need that helper for anything the daemon tarball touches;
+      # node-pty's own install script we re-run explicitly via `npm rebuild`.
+      - name: Install deps (host, skip postinstalls)
+        run: npm ci --ignore-scripts
+
+      - name: Rebuild node-pty (host, native x64)
+        if: matrix.docker_platform == ''
+        run: npm rebuild node-pty
+
+      - name: Build daemon TS output
+        run: npm run build:daemon
+
       - name: Build tarball (native x64)
         if: matrix.docker_platform == ''
-        run: |
-          npm install
-          npm run build:daemon
-          ARCH=${{ matrix.arch }} bash scripts/build-daemon-tarball.sh
+        run: ARCH=${{ matrix.arch }} bash scripts/build-daemon-tarball.sh
 
       - name: Build tarball (emulated arm)
         if: matrix.docker_platform != ''
         run: |
-          # Run npm install + build inside a matching-arch container so
-          # node-pty compiles for the target ABI. The tarball script then
-          # downloads the arch-matched Node binary from nodejs.org.
+          # Only the arch-sensitive parts run in the container: rebuild node-pty
+          # for the target ABI + assemble the tarball. dist/daemon and the rest
+          # of node_modules come from the host install via the volume mount.
           docker run --rm --platform ${{ matrix.docker_platform }} \
             -v "${{ github.workspace }}:/work" -w /work \
             node:20-bookworm \
-            bash -c "npm install && npm run build:daemon && ARCH=${{ matrix.arch }} bash scripts/build-daemon-tarball.sh"
+            bash -c "npm rebuild node-pty && ARCH=${{ matrix.arch }} bash scripts/build-daemon-tarball.sh"
 
       - name: Verify tarball
         run: |


### PR DESCRIPTION
Fixes the release-workflow failure on the arm matrix jobs.

## Root cause
`electron-winstaller` (transitive dep of electron-builder) copies an arch-specific 7-Zip binary in its postinstall — and only ships x64 + arm64 variants, not armv7l. Inside the QEMU-emulated armv7l container, `npm install` triggers the postinstall → `ENOENT: vendor/7z-arm.exe` → npm exits 1 → job fails.

It's Windows-only tooling we never invoke on Linux AppImage builds.

## Fix
Host does `npm ci --ignore-scripts` (all postinstalls skipped, sidestepping electron-winstaller everywhere), plus explicit `npm rebuild node-pty` — that's the only native module the daemon tarball actually needs. Arm containers only do `npm rebuild node-pty` (which triggers node-gyp under the target ABI) + the tarball script. TS build moved to host (arch-agnostic).

Net: only truly arch-sensitive work runs inside the QEMU containers.

## Test plan
- [ ] Merge → re-dispatch release workflow → all three build-tarball matrix jobs succeed
- [ ] build-appimage assembles a multi-arch AppImage
- [ ] Downstream tag push publishes a proper release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrqJNfkeYjbet6eQs71vCK