### PR TITLE
chore: bump to 0.5.0-rc.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchboard",
-  "version": "0.5.0-rc.13",
+  "version": "0.5.0-rc.14",
   "description": "A Slack-style multi-session terminal manager for AI coding workflows",
   "main": "dist/main/main/main.js",
   "scripts": {

--- a/specs/src/renderer/components/TerminalPane-spec.md
+++ b/specs/src/renderer/components/TerminalPane-spec.md
@@ -1,6 +1,6 @@
 ---
 title: Terminal Pane Component Specification
-version: 0.3.0
+version: 0.3.1
 maintained_by: claude
 domain_tags: [renderer, react, xterm, terminal]
 status: active
@@ -51,7 +51,8 @@ interface TerminalPaneProps {
 - **WebGL addon**: attached after `terminal.open()` via `tryAttachWebgl()`. Falls back to canvas renderer if the addon fails to load or attach.
 
 ## Clipboard
-- **Ctrl+Shift+C** — copy the current terminal selection to the system clipboard via `navigator.clipboard.writeText(terminal.getSelection())`. Only fires when `terminal.hasSelection()` is true; otherwise the shortcut is a no-op (but still consumed, matching gnome-terminal / konsole behavior). Plain Ctrl+C is NEVER intercepted — it always reaches the PTY as SIGINT.
+- **Ctrl+Shift+C** — copy the current terminal selection to the system clipboard via `navigator.clipboard.writeText(...)`. Detected by `event.code === 'KeyC'` (physical key, layout-independent). If no selection exists the shortcut is a no-op but still consumed, matching gnome-terminal / konsole behavior. Plain Ctrl+C is NEVER intercepted — it always reaches the PTY as SIGINT.
+- **Selection cache** — the pane subscribes to `terminal.onSelectionChange` and stores the most recent non-empty selection in a closure. The copy handler prefers `terminal.getSelection()` but falls back to the cache when it is empty. This works around xterm.js's behavior in mouse-tracking mode where TUI apps (Claude Code, tmux, vim) can drop the live selection on mouseup, leaving `getSelection()` empty at keypress time. The cache is consumed (cleared) on every copy so a stale selection cannot be re-copied. See xtermjs/xterm.js#4781 for the underlying regression class.
 - **Paste** — handled by the browser's native paste event, which xterm.js consumes automatically. No custom code path.
 - Clipboard writes that fail (e.g. window not focused, permission denied) are swallowed — the terminal remains functional and the user can retry.
 - Wired via `terminal.attachCustomKeyEventHandler`, which returns `false` for the consumed shortcut and `true` for every other keydown so xterm's default handling is preserved.

--- a/src/renderer/components/TerminalPane.tsx
+++ b/src/renderer/components/TerminalPane.tsx
@@ -96,16 +96,27 @@ export default function TerminalPane({ sessionId, visible, searchVisible, onSear
     // Linux-terminal convention — plain Ctrl+C stays reserved for SIGINT).
     // Paste (Ctrl+Shift+V) is handled by the browser's default paste event,
     // which xterm.js consumes automatically.
+    //
+    // The selection is cached via onSelectionChange because TUI apps with
+    // mouse tracking (Claude Code, tmux, vim) can drop the live selection
+    // on mouseup, so terminal.getSelection() is empty by the time the user
+    // presses the copy shortcut. See xtermjs/xterm.js#4781.
+    let lastSelection = '';
+    const selectionSubscription = terminal.onSelectionChange(() => {
+      const current = terminal.getSelection();
+      if (current.length > 0) lastSelection = current;
+    });
+
     terminal.attachCustomKeyEventHandler((event) => {
       if (event.type !== 'keydown') return true;
-      if (event.ctrlKey && event.shiftKey && (event.key === 'C' || event.key === 'c')) {
-        if (terminal.hasSelection()) {
-          navigator.clipboard.writeText(terminal.getSelection()).catch(() => {
-            // Clipboard write can fail if the window isn't focused; fall
-            // back to Electron's clipboard via the preload bridge if the
-            // renderer path is blocked. For now, swallow — user can retry.
+      if (event.ctrlKey && event.shiftKey && event.code === 'KeyC') {
+        const text = terminal.getSelection() || lastSelection;
+        if (text) {
+          navigator.clipboard.writeText(text).catch(() => {
+            // Clipboard write can fail if the window isn't focused; swallow.
           });
         }
+        lastSelection = '';
         return false;
       }
       return true;
@@ -165,6 +176,7 @@ export default function TerminalPane({ sessionId, visible, searchVisible, onSear
     return () => {
       window.removeEventListener('resize', handleResize);
       unsubData();
+      selectionSubscription.dispose();
       terminal.dispose();
     };
   }, [sessionId, !!prefs.terminalBackgroundImage]);

--- a/tests/renderer/App.test.tsx
+++ b/tests/renderer/App.test.tsx
@@ -11,6 +11,7 @@ vi.mock('@xterm/xterm', () => ({
     attachCustomKeyEventHandler: vi.fn(),
     hasSelection: vi.fn().mockReturnValue(false),
     getSelection: vi.fn().mockReturnValue(''),
+    onSelectionChange: vi.fn().mockReturnValue({ dispose: vi.fn() }),
     cols: 80, rows: 24,
     options: {},
   })),

--- a/tests/renderer/TerminalPane.test.tsx
+++ b/tests/renderer/TerminalPane.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@xterm/xterm', () => ({
     attachCustomKeyEventHandler: vi.fn(),
     hasSelection: vi.fn().mockReturnValue(false),
     getSelection: vi.fn().mockReturnValue(''),
+    onSelectionChange: vi.fn().mockReturnValue({ dispose: vi.fn() }),
     cols: 80,
     rows: 24,
     options: {},

--- a/tests/renderer/state/preferences.test.tsx
+++ b/tests/renderer/state/preferences.test.tsx
@@ -12,6 +12,7 @@ vi.mock('@xterm/xterm', () => ({
     attachCustomKeyEventHandler: vi.fn(),
     hasSelection: vi.fn().mockReturnValue(false),
     getSelection: vi.fn().mockReturnValue(''),
+    onSelectionChange: vi.fn().mockReturnValue({ dispose: vi.fn() }),
     cols: 80, rows: 24,
   })),
 }));


### PR DESCRIPTION
Ships the TUI copy fix alongside the version bump.

**What changed since rc.13:**
- `feat(renderer)`: Ctrl+Shift+C copies terminal selection to clipboard (PR #60)
- `fix(renderer)`: cache selection via `onSelectionChange` so copy works in TUIs (Claude Code, tmux, vim) — xterm.js drops the live selection on mouseup in mouse-tracking mode. Also switched key detection to `event.code === 'KeyC'` (layout-independent).
- `chore`: bump to 0.5.0-rc.14

Pattern matches Wave, Hyper, Tabby. Refs xtermjs/xterm.js#4781.

**Local validation:**
- 356/356 tests pass
- x86_64 AppImage built: `release/Switchboard-0.5.0-rc.14.AppImage` (142 MB)

After merge, tag `v0.5.0-rc.14` → CI runs the full matrix and attaches the multi-arch release.